### PR TITLE
update Sony IDTs for consistency

### DIFF
--- a/sony/CSC.Sony.ACES_to_Venice_SLog3_SGamut3.ctl
+++ b/sony/CSC.Sony.ACES_to_Venice_SLog3_SGamut3.ctl
@@ -1,12 +1,12 @@
 
-// <ACEStransformID>urn:ampas:aces:transformId:v2.0:CSC.Sony.ACES_to_SLog3_Venice_SGamut3.a2.v1</ACEStransformID>
-// <ACESuserName>ACES2065-1 to Sony S-Log3 VENICE S-Gamut3</ACESuserName>
+// <ACEStransformID>urn:ampas:aces:transformId:v2.0:CSC.Sony.ACES_to_Venice_SLog3_SGamut3.a2.v1</ACEStransformID>
+// <ACESuserName>ACES2065-1 to Sony VENICE S-Log3 S-Gamut3</ACESuserName>
 
 //
-// ACES Color Space Conversion - ACES to Sony S-Log3 VENICE S-Gamut3
+// ACES Color Space Conversion - ACES to Sony VENICE S-Log3 S-Gamut3
 //
 // converts ACES2065-1 (AP0 w/ linear encoding) to
-//          Sony S-Log3 VENICE S-Gamut3
+//          Sony VENICE S-Log3 S-Gamut3
 //
 
 

--- a/sony/CSC.Sony.ACES_to_Venice_SLog3_SGamut3Cine.ctl
+++ b/sony/CSC.Sony.ACES_to_Venice_SLog3_SGamut3Cine.ctl
@@ -1,12 +1,12 @@
 
-// <ACEStransformID>urn:ampas:aces:transformId:v2.0:CSC.Sony.ACES_to_SLog3_Venice_SGamut3Cine.a2.v1</ACEStransformID>
-// <ACESuserName>ACES2065-1 to Sony S-Log3 VENICE S-Gamut3.Cine</ACESuserName>
+// <ACEStransformID>urn:ampas:aces:transformId:v2.0:CSC.Sony.ACES_to_Venice_SLog3_SGamut3Cine.a2.v1</ACEStransformID>
+// <ACESuserName>ACES2065-1 to Sony VENICE S-Log3 S-Gamut3.Cine</ACESuserName>
 
 //
-// ACES Color Space Conversion - ACES to Sony S-Log3 VENICE S-Gamut3.Cine
+// ACES Color Space Conversion - ACES to Sony VENICE S-Log3 S-Gamut3.Cine
 //
 // converts ACES2065-1 (AP0 w/ linear encoding) to
-//          Sony S-Log3 VENICE S-Gamut3.Cine
+//          Sony VENICE S-Log3 S-Gamut3.Cine
 //
 
 

--- a/sony/CSC.Sony.Venice_SLog3_SGamut3Cine_to_ACES.ctl
+++ b/sony/CSC.Sony.Venice_SLog3_SGamut3Cine_to_ACES.ctl
@@ -1,11 +1,11 @@
 
 // <ACEStransformID>urn:ampas:aces:transformId:v2.0:CSC.Sony.Venice_SLog3_SGamut3Cine_to_ACES.a2.v1</ACEStransformID>
-// <ACESuserName>Sony Venice S-Log3 S-Gamut3Cine to ACES2065-1</ACESuserName>
+// <ACESuserName>Sony VENICE S-Log3 S-Gamut3Cine to ACES2065-1</ACESuserName>
 
 //
-// ACES Color Space Conversion - Sony Venice S-Log3 S-Gamut3Cine to ACES
+// ACES Color Space Conversion - Sony VENICE S-Log3 S-Gamut3Cine to ACES
 //
-// converts Sony Venice S-Log3 / S-Gamut3Cine to
+// converts Sony VENICE S-Log3 / S-Gamut3Cine to
 //          ACES2065-1 (AP0 w/ linear encoding)
 //
 

--- a/sony/CSC.Sony.Venice_SLog3_SGamut3_to_ACES.ctl
+++ b/sony/CSC.Sony.Venice_SLog3_SGamut3_to_ACES.ctl
@@ -1,11 +1,11 @@
 
 // <ACEStransformID>urn:ampas:aces:transformId:v2.0:CSC.Sony.Venice_SLog3_SGamut3_to_ACES.a2.v1</ACEStransformID>
-// <ACESuserName>Sony Venice S-Log3 S-Gamut3 to ACES2065-1</ACESuserName>
+// <ACESuserName>Sony VENICE S-Log3 S-Gamut3 to ACES2065-1</ACESuserName>
 
 //
-// ACES Color Space Conversion - Sony Venice S-Log3 S-Gamut3 to ACES
+// ACES Color Space Conversion - Sony VENICE S-Log3 S-Gamut3 to ACES
 //
-// converts Sony Venice S-Log3 / S-Gamut3 to
+// converts Sony VENICE S-Log3 / S-Gamut3 to
 //          ACES2065-1 (AP0 w/ linear encoding)
 //
 


### PR DESCRIPTION
Consistently puts VENICE (or Venice) first and then mentions S-Log3 (or SLog3)