### PR TITLE
Fix typos in defining and applying AP0<->AWG4 conversion matrices

### DIFF
--- a/arri/CSC.Arri.ACES_to_LogCv4.ctl
+++ b/arri/CSC.Arri.ACES_to_LogCv4.ctl
@@ -61,8 +61,8 @@ void main(input varying float rIn,
 
     float lin_AWG4[3] = mult_f3_f33(ACES, AP0_to_AWG4_MAT);
 
-    rOut = RelativeSceneLinearToNormalizedLogC4(line_AWG4[0]);
-    gOut = RelativeSceneLinearToNormalizedLogC4(line_AWG4[1]);
-    bOut = RelativeSceneLinearToNormalizedLogC4(line_AWG4[2]);
+    rOut = RelativeSceneLinearToNormalizedLogC4(lin_AWG4[0]);
+    gOut = RelativeSceneLinearToNormalizedLogC4(lin_AWG4[1]);
+    bOut = RelativeSceneLinearToNormalizedLogC4(lin_AWG4[2]);
     aOut = aIn;
 }

--- a/arri/CSC.Arri.ACES_to_LogCv4.ctl 
+++ b/arri/CSC.Arri.ACES_to_LogCv4.ctl 
@@ -26,9 +26,9 @@ const Chromaticities ARRI_ALEXA_WG4_PRI =
         {0.0991, -0.0308},
         {0.3127, 0.3290}};
 
-const float AWG_to_AP0_MAT[3][3] = calculate_rgb_to_rgb_matrix(ARRI_ALEXA_WG4_PRI,
-                                                               AP0,
-                                                               CONE_RESP_MAT_CAT02);
+const float AP0_to_AWG4_MAT[3][3] = calculate_rgb_to_rgb_matrix(AP0,
+                                                                ARRI_ALEXA_WG4_PRI,
+                                                                CONE_RESP_MAT_CAT02);
 
 // LogC4 Curve Decoding Function
 float RelativeSceneLinearToNormalizedLogC4(float x)
@@ -59,7 +59,7 @@ void main(input varying float rIn,
 {
     float ACES[3] = {rIn, gIn, bIn};
 
-    float lin_AWG4[3] = mult_f3_f33(ACES, AW0_to_AWG4_MAT);
+    float lin_AWG4[3] = mult_f3_f33(ACES, AP0_to_AWG4_MAT);
 
     rOut = RelativeSceneLinearToNormalizedLogC4(line_AWG4[0]);
     gOut = RelativeSceneLinearToNormalizedLogC4(line_AWG4[1]);

--- a/arri/CSC.Arri.LogCv4_to_ACES.ctl
+++ b/arri/CSC.Arri.LogCv4_to_ACES.ctl
@@ -26,8 +26,8 @@ const Chromaticities ARRI_ALEXA_WG4_PRI =
         {0.0991, -0.0308},
         {0.3127, 0.3290}};
 
-const float AP0_to_AWG4_MAT[3][3] = calculate_rgb_to_rgb_matrix(AP0,
-                                                                ARRI_ALEXA_WG4_PRI,
+const float AWG4_to_AP0_MAT[3][3] = calculate_rgb_to_rgb_matrix(ARRI_ALEXA_WG4_PRI,
+                                                                AP0,
                                                                 CONE_RESP_MAT_CAT02);
 
 // LogC4 Curve Decoding Function
@@ -64,7 +64,7 @@ void main(input varying float rIn,
     lin_AWG4[1] = normalizedLogC4ToRelativeSceneLinear(gIn);
     lin_AWG4[2] = normalizedLogC4ToRelativeSceneLinear(bIn);
 
-    float ACES[3] = mult_f3_f33(lin_AWG4, AP0_to_AWG4_MAT);
+    float ACES[3] = mult_f3_f33(lin_AWG4, AWG4_to_AP0_MAT);
 
     rOut = ACES[0];
     gOut = ACES[1];


### PR DESCRIPTION
ACES_to_LogCv4 transform was incorrectly using `AWG4_to_AP0_MAT` instead of `AP0_to_AWG4_MAT`.

LogCv4_to_ACES transform was incorrectly using `AP0_to_AWG4_MAT` instead of `AWG4_to_AP0_MAT`.
