### PR TITLE
Add LogC v3 EI presets

### DIFF
--- a/arri/CSC.Arri.ACES_to_LogCv3-EI1000.ctl
+++ b/arri/CSC.Arri.ACES_to_LogCv3-EI1000.ctl
@@ -10,6 +10,7 @@
 
 import "Lib.Academy.Utilities";
 import "Lib.Academy.ColorSpaces";
+import "Lib.Arri.LogC3";
 
 const Chromaticities AP0 = // ACES Primaries from SMPTE ST2065-1
     {
@@ -29,59 +30,7 @@ const float AP0_to_AWG3_MAT[3][3] = calculate_rgb_to_rgb_matrix(AP0,
                                                                 ARRI_ALEXA_WG_PRI,
                                                                 CONE_RESP_MAT_CAT02);
 
-const float nominalEI = 400.0;
-const float blackSignal = 16.0 / 4095.0;
-const float midGraySignal = 0.01;
-const float encodingGain = 500.0 / 1023.0 * 0.525;
-const float encodingOffset = 400.0 / 1023.0;
-const float cut = 1.0 / 9.0;
-const float slope = 1.0 / (cut * log(10.0));
-const float offset = log10(cut) - slope * cut;
-
-float relativeExposureToNormalizedSensor(float re, float EI)
-{
-    return re * (midGraySignal * nominalEI / EI) / 0.18 + blackSignal;
-}
-
-float relativeExposureToNormalizedLogC3(float re, float EI)
-{
-    float nz;
-    float out;
-    float ns;
-    const float gain = EI / nominalEI;
-    const float gray = midGraySignal / gain;
-    const float encGain = (log2(gain) * (0.89 - 1.0) / 3.0 + 1.0) * encodingGain;
-    float encOffset = encodingOffset;
-    for (int i = 0; i < 3; i = i + 1)
-    {
-        nz = ((95.0 / 1023.0 - encOffset) / encGain - offset) / slope;
-        encOffset = encodingOffset - log10(1.0 + nz) * encGain;
-    }
-    float xm = log10((1.0 - blackSignal) / gray + nz) * encGain + encOffset;
-
-    ns = relativeExposureToNormalizedSensor(re, EI);
-
-    ns = (ns - blackSignal) / gray + nz;
-
-    if (xm > 1) {
-        // Hermite blending region
-        // Tricky to implement an inverse unless needed. It might be possible to
-        // iteratively solve for a numerical inversion, but is currently not
-        // supported.
-        return 0;
-    } else { // Valid for EI values below 1600
-        if (ns > cut)
-        {
-            out = log10(ns);
-        } 
-        else
-        {
-            out = slope * ns + offset;
-        }
-    }
-
-    return out * encGain + encOffset;
-}
+const float EI = 1000.0;
 
 void main(input varying float rIn,
           input varying float gIn,
@@ -90,8 +39,7 @@ void main(input varying float rIn,
           output varying float rOut,
           output varying float gOut,
           output varying float bOut,
-          output varying float aOut,
-          input uniform float EI = 1000.0)
+          output varying float aOut)
 {
     float ACES[3] = {rIn, gIn, bIn};
 

--- a/arri/CSC.Arri.ACES_to_LogCv3-EI1000.ctl
+++ b/arri/CSC.Arri.ACES_to_LogCv3-EI1000.ctl
@@ -1,16 +1,11 @@
-// <ACEStransformID>urn:ampas:aces:transformId:v2.0:CSC.Arri.ACES_to_LogC3.a2.v1</ACEStransformID>
-// <ACESuserName>ACES2065-1 to ARRI LogC3</ACESuserName>
+// <ACEStransformID>urn:ampas:aces:transformId:v2.0:CSC.Arri.ACES_to_LogC3-EI1000.a2.v1</ACEStransformID>
+// <ACESuserName>ACES2065-1 to ARRI LogC3 EI1000</ACESuserName>
 
 //
-// ACES Color Space Conversion - ACES2065-1 to Arri LogC3
+// ACES Color Space Conversion - ACES2065-1 to Arri LogC3 EI1000
 //
 // converts ACES2065-1 (AP0 w/ linear encoding) to
-//          Arri LogC3
-//
-//  NOTE: Like its LogC3-to-ACES counterpart, this ACES-to-LogC3 transform
-//  declares EI as a parameter, but defaults to 800. Due to the Hermite spline
-//  blending region between 0.8 and 1.0, the function currently will only work
-//  for EI values below 1600.
+//          Arri LogC3 EI1000
 //
 
 import "Lib.Academy.Utilities";
@@ -96,7 +91,7 @@ void main(input varying float rIn,
           output varying float gOut,
           output varying float bOut,
           output varying float aOut,
-          input uniform float EI = 800.0)
+          input uniform float EI = 1000.0)
 {
     float ACES[3] = {rIn, gIn, bIn};
 

--- a/arri/CSC.Arri.ACES_to_LogCv3-EI1000.ctl
+++ b/arri/CSC.Arri.ACES_to_LogCv3-EI1000.ctl
@@ -1,0 +1,109 @@
+// <ACEStransformID>urn:ampas:aces:transformId:v2.0:CSC.Arri.ACES_to_LogC3.a2.v1</ACEStransformID>
+// <ACESuserName>ACES2065-1 to ARRI LogC3</ACESuserName>
+
+//
+// ACES Color Space Conversion - ACES2065-1 to Arri LogC3
+//
+// converts ACES2065-1 (AP0 w/ linear encoding) to
+//          Arri LogC3
+//
+//  NOTE: Like its LogC3-to-ACES counterpart, this ACES-to-LogC3 transform
+//  declares EI as a parameter, but defaults to 800. Due to the Hermite spline
+//  blending region between 0.8 and 1.0, the function currently will only work
+//  for EI values below 1600.
+//
+
+import "Lib.Academy.Utilities";
+import "Lib.Academy.ColorSpaces";
+
+const Chromaticities AP0 = // ACES Primaries from SMPTE ST2065-1
+    {
+        {0.73470, 0.26530},
+        {0.00000, 1.00000},
+        {0.00010, -0.07700},
+        {0.32168, 0.33767}};
+
+const Chromaticities ARRI_ALEXA_WG_PRI =
+    {
+        {0.68400, 0.31300},
+        {0.22100, 0.84800},
+        {0.08610, -0.10200},
+        {0.31270, 0.32900}};
+
+const float AP0_to_AWG3_MAT[3][3] = calculate_rgb_to_rgb_matrix(AP0,
+                                                                ARRI_ALEXA_WG_PRI,
+                                                                CONE_RESP_MAT_CAT02);
+
+const float nominalEI = 400.0;
+const float blackSignal = 16.0 / 4095.0;
+const float midGraySignal = 0.01;
+const float encodingGain = 500.0 / 1023.0 * 0.525;
+const float encodingOffset = 400.0 / 1023.0;
+const float cut = 1.0 / 9.0;
+const float slope = 1.0 / (cut * log(10.0));
+const float offset = log10(cut) - slope * cut;
+
+float relativeExposureToNormalizedSensor(float re, float EI)
+{
+    return re * (midGraySignal * nominalEI / EI) / 0.18 + blackSignal;
+}
+
+float relativeExposureToNormalizedLogC3(float re, float EI)
+{
+    float nz;
+    float out;
+    float ns;
+    const float gain = EI / nominalEI;
+    const float gray = midGraySignal / gain;
+    const float encGain = (log2(gain) * (0.89 - 1.0) / 3.0 + 1.0) * encodingGain;
+    float encOffset = encodingOffset;
+    for (int i = 0; i < 3; i = i + 1)
+    {
+        nz = ((95.0 / 1023.0 - encOffset) / encGain - offset) / slope;
+        encOffset = encodingOffset - log10(1.0 + nz) * encGain;
+    }
+    float xm = log10((1.0 - blackSignal) / gray + nz) * encGain + encOffset;
+
+    ns = relativeExposureToNormalizedSensor(re, EI);
+
+    ns = (ns - blackSignal) / gray + nz;
+
+    if (xm > 1) {
+        // Hermite blending region
+        // Tricky to implement an inverse unless needed. It might be possible to
+        // iteratively solve for a numerical inversion, but is currently not
+        // supported.
+        return 0;
+    } else { // Valid for EI values below 1600
+        if (ns > cut)
+        {
+            out = log10(ns);
+        } 
+        else
+        {
+            out = slope * ns + offset;
+        }
+    }
+
+    return out * encGain + encOffset;
+}
+
+void main(input varying float rIn,
+          input varying float gIn,
+          input varying float bIn,
+          input varying float aIn,
+          output varying float rOut,
+          output varying float gOut,
+          output varying float bOut,
+          output varying float aOut,
+          input uniform float EI = 800.0)
+{
+    float ACES[3] = {rIn, gIn, bIn};
+
+    float lin_AWG3[3] = mult_f3_f33(ACES, AP0_to_AWG3_MAT);
+
+    rOut = relativeExposureToNormalizedLogC3(lin_AWG3[0], EI);
+    gOut = relativeExposureToNormalizedLogC3(lin_AWG3[1], EI);
+    bOut = relativeExposureToNormalizedLogC3(lin_AWG3[2], EI);
+    aOut = aIn;
+}

--- a/arri/CSC.Arri.ACES_to_LogCv3-EI1000.ctl
+++ b/arri/CSC.Arri.ACES_to_LogCv3-EI1000.ctl
@@ -9,26 +9,7 @@
 //
 
 import "Lib.Academy.Utilities";
-import "Lib.Academy.ColorSpaces";
 import "Lib.Arri.LogC3";
-
-const Chromaticities AP0 = // ACES Primaries from SMPTE ST2065-1
-    {
-        {0.73470, 0.26530},
-        {0.00000, 1.00000},
-        {0.00010, -0.07700},
-        {0.32168, 0.33767}};
-
-const Chromaticities ARRI_ALEXA_WG_PRI =
-    {
-        {0.68400, 0.31300},
-        {0.22100, 0.84800},
-        {0.08610, -0.10200},
-        {0.31270, 0.32900}};
-
-const float AP0_to_AWG3_MAT[3][3] = calculate_rgb_to_rgb_matrix(AP0,
-                                                                ARRI_ALEXA_WG_PRI,
-                                                                CONE_RESP_MAT_CAT02);
 
 const float EI = 1000.0;
 

--- a/arri/CSC.Arri.ACES_to_LogCv3-EI1280.ctl
+++ b/arri/CSC.Arri.ACES_to_LogCv3-EI1280.ctl
@@ -1,0 +1,104 @@
+// <ACEStransformID>urn:ampas:aces:transformId:v2.0:CSC.Arri.ACES_to_LogC3-EI1280.a2.v1</ACEStransformID>
+// <ACESuserName>ACES2065-1 to ARRI LogC3 EI1280</ACESuserName>
+
+//
+// ACES Color Space Conversion - ACES2065-1 to Arri LogC3 EI1280
+//
+// converts ACES2065-1 (AP0 w/ linear encoding) to
+//          Arri LogC3 EI1280
+//
+
+import "Lib.Academy.Utilities";
+import "Lib.Academy.ColorSpaces";
+
+const Chromaticities AP0 = // ACES Primaries from SMPTE ST2065-1
+    {
+        {0.73470, 0.26530},
+        {0.00000, 1.00000},
+        {0.00010, -0.07700},
+        {0.32168, 0.33767}};
+
+const Chromaticities ARRI_ALEXA_WG_PRI =
+    {
+        {0.68400, 0.31300},
+        {0.22100, 0.84800},
+        {0.08610, -0.10200},
+        {0.31270, 0.32900}};
+
+const float AP0_to_AWG3_MAT[3][3] = calculate_rgb_to_rgb_matrix(AP0,
+                                                                ARRI_ALEXA_WG_PRI,
+                                                                CONE_RESP_MAT_CAT02);
+
+const float nominalEI = 400.0;
+const float blackSignal = 16.0 / 4095.0;
+const float midGraySignal = 0.01;
+const float encodingGain = 500.0 / 1023.0 * 0.525;
+const float encodingOffset = 400.0 / 1023.0;
+const float cut = 1.0 / 9.0;
+const float slope = 1.0 / (cut * log(10.0));
+const float offset = log10(cut) - slope * cut;
+
+float relativeExposureToNormalizedSensor(float re, float EI)
+{
+    return re * (midGraySignal * nominalEI / EI) / 0.18 + blackSignal;
+}
+
+float relativeExposureToNormalizedLogC3(float re, float EI)
+{
+    float nz;
+    float out;
+    float ns;
+    const float gain = EI / nominalEI;
+    const float gray = midGraySignal / gain;
+    const float encGain = (log2(gain) * (0.89 - 1.0) / 3.0 + 1.0) * encodingGain;
+    float encOffset = encodingOffset;
+    for (int i = 0; i < 3; i = i + 1)
+    {
+        nz = ((95.0 / 1023.0 - encOffset) / encGain - offset) / slope;
+        encOffset = encodingOffset - log10(1.0 + nz) * encGain;
+    }
+    float xm = log10((1.0 - blackSignal) / gray + nz) * encGain + encOffset;
+
+    ns = relativeExposureToNormalizedSensor(re, EI);
+
+    ns = (ns - blackSignal) / gray + nz;
+
+    if (xm > 1) {
+        // Hermite blending region
+        // Tricky to implement an inverse unless needed. It might be possible to
+        // iteratively solve for a numerical inversion, but is currently not
+        // supported.
+        return 0;
+    } else { // Valid for EI values below 1600
+        if (ns > cut)
+        {
+            out = log10(ns);
+        } 
+        else
+        {
+            out = slope * ns + offset;
+        }
+    }
+
+    return out * encGain + encOffset;
+}
+
+void main(input varying float rIn,
+          input varying float gIn,
+          input varying float bIn,
+          input varying float aIn,
+          output varying float rOut,
+          output varying float gOut,
+          output varying float bOut,
+          output varying float aOut,
+          input uniform float EI = 1280.0)
+{
+    float ACES[3] = {rIn, gIn, bIn};
+
+    float lin_AWG3[3] = mult_f3_f33(ACES, AP0_to_AWG3_MAT);
+
+    rOut = relativeExposureToNormalizedLogC3(lin_AWG3[0], EI);
+    gOut = relativeExposureToNormalizedLogC3(lin_AWG3[1], EI);
+    bOut = relativeExposureToNormalizedLogC3(lin_AWG3[2], EI);
+    aOut = aIn;
+}

--- a/arri/CSC.Arri.ACES_to_LogCv3-EI1280.ctl
+++ b/arri/CSC.Arri.ACES_to_LogCv3-EI1280.ctl
@@ -10,6 +10,7 @@
 
 import "Lib.Academy.Utilities";
 import "Lib.Academy.ColorSpaces";
+import "Lib.Arri.LogC3";
 
 const Chromaticities AP0 = // ACES Primaries from SMPTE ST2065-1
     {
@@ -29,59 +30,7 @@ const float AP0_to_AWG3_MAT[3][3] = calculate_rgb_to_rgb_matrix(AP0,
                                                                 ARRI_ALEXA_WG_PRI,
                                                                 CONE_RESP_MAT_CAT02);
 
-const float nominalEI = 400.0;
-const float blackSignal = 16.0 / 4095.0;
-const float midGraySignal = 0.01;
-const float encodingGain = 500.0 / 1023.0 * 0.525;
-const float encodingOffset = 400.0 / 1023.0;
-const float cut = 1.0 / 9.0;
-const float slope = 1.0 / (cut * log(10.0));
-const float offset = log10(cut) - slope * cut;
-
-float relativeExposureToNormalizedSensor(float re, float EI)
-{
-    return re * (midGraySignal * nominalEI / EI) / 0.18 + blackSignal;
-}
-
-float relativeExposureToNormalizedLogC3(float re, float EI)
-{
-    float nz;
-    float out;
-    float ns;
-    const float gain = EI / nominalEI;
-    const float gray = midGraySignal / gain;
-    const float encGain = (log2(gain) * (0.89 - 1.0) / 3.0 + 1.0) * encodingGain;
-    float encOffset = encodingOffset;
-    for (int i = 0; i < 3; i = i + 1)
-    {
-        nz = ((95.0 / 1023.0 - encOffset) / encGain - offset) / slope;
-        encOffset = encodingOffset - log10(1.0 + nz) * encGain;
-    }
-    float xm = log10((1.0 - blackSignal) / gray + nz) * encGain + encOffset;
-
-    ns = relativeExposureToNormalizedSensor(re, EI);
-
-    ns = (ns - blackSignal) / gray + nz;
-
-    if (xm > 1) {
-        // Hermite blending region
-        // Tricky to implement an inverse unless needed. It might be possible to
-        // iteratively solve for a numerical inversion, but is currently not
-        // supported.
-        return 0;
-    } else { // Valid for EI values below 1600
-        if (ns > cut)
-        {
-            out = log10(ns);
-        } 
-        else
-        {
-            out = slope * ns + offset;
-        }
-    }
-
-    return out * encGain + encOffset;
-}
+const float EI = 1280.0;
 
 void main(input varying float rIn,
           input varying float gIn,
@@ -90,8 +39,7 @@ void main(input varying float rIn,
           output varying float rOut,
           output varying float gOut,
           output varying float bOut,
-          output varying float aOut,
-          input uniform float EI = 1280.0)
+          output varying float aOut)
 {
     float ACES[3] = {rIn, gIn, bIn};
 

--- a/arri/CSC.Arri.ACES_to_LogCv3-EI1280.ctl
+++ b/arri/CSC.Arri.ACES_to_LogCv3-EI1280.ctl
@@ -9,26 +9,7 @@
 //
 
 import "Lib.Academy.Utilities";
-import "Lib.Academy.ColorSpaces";
 import "Lib.Arri.LogC3";
-
-const Chromaticities AP0 = // ACES Primaries from SMPTE ST2065-1
-    {
-        {0.73470, 0.26530},
-        {0.00000, 1.00000},
-        {0.00010, -0.07700},
-        {0.32168, 0.33767}};
-
-const Chromaticities ARRI_ALEXA_WG_PRI =
-    {
-        {0.68400, 0.31300},
-        {0.22100, 0.84800},
-        {0.08610, -0.10200},
-        {0.31270, 0.32900}};
-
-const float AP0_to_AWG3_MAT[3][3] = calculate_rgb_to_rgb_matrix(AP0,
-                                                                ARRI_ALEXA_WG_PRI,
-                                                                CONE_RESP_MAT_CAT02);
 
 const float EI = 1280.0;
 

--- a/arri/CSC.Arri.ACES_to_LogCv3-EI160.ctl
+++ b/arri/CSC.Arri.ACES_to_LogCv3-EI160.ctl
@@ -1,0 +1,104 @@
+// <ACEStransformID>urn:ampas:aces:transformId:v2.0:CSC.Arri.ACES_to_LogC3-EI160.a2.v1</ACEStransformID>
+// <ACESuserName>ACES2065-1 to ARRI LogC3 EI160</ACESuserName>
+
+//
+// ACES Color Space Conversion - ACES2065-1 to Arri LogC3 EI160
+//
+// converts ACES2065-1 (AP0 w/ linear encoding) to
+//          Arri LogC3 EI160
+//
+
+import "Lib.Academy.Utilities";
+import "Lib.Academy.ColorSpaces";
+
+const Chromaticities AP0 = // ACES Primaries from SMPTE ST2065-1
+    {
+        {0.73470, 0.26530},
+        {0.00000, 1.00000},
+        {0.00010, -0.07700},
+        {0.32168, 0.33767}};
+
+const Chromaticities ARRI_ALEXA_WG_PRI =
+    {
+        {0.68400, 0.31300},
+        {0.22100, 0.84800},
+        {0.08610, -0.10200},
+        {0.31270, 0.32900}};
+
+const float AP0_to_AWG3_MAT[3][3] = calculate_rgb_to_rgb_matrix(AP0,
+                                                                ARRI_ALEXA_WG_PRI,
+                                                                CONE_RESP_MAT_CAT02);
+
+const float nominalEI = 400.0;
+const float blackSignal = 16.0 / 4095.0;
+const float midGraySignal = 0.01;
+const float encodingGain = 500.0 / 1023.0 * 0.525;
+const float encodingOffset = 400.0 / 1023.0;
+const float cut = 1.0 / 9.0;
+const float slope = 1.0 / (cut * log(10.0));
+const float offset = log10(cut) - slope * cut;
+
+float relativeExposureToNormalizedSensor(float re, float EI)
+{
+    return re * (midGraySignal * nominalEI / EI) / 0.18 + blackSignal;
+}
+
+float relativeExposureToNormalizedLogC3(float re, float EI)
+{
+    float nz;
+    float out;
+    float ns;
+    const float gain = EI / nominalEI;
+    const float gray = midGraySignal / gain;
+    const float encGain = (log2(gain) * (0.89 - 1.0) / 3.0 + 1.0) * encodingGain;
+    float encOffset = encodingOffset;
+    for (int i = 0; i < 3; i = i + 1)
+    {
+        nz = ((95.0 / 1023.0 - encOffset) / encGain - offset) / slope;
+        encOffset = encodingOffset - log10(1.0 + nz) * encGain;
+    }
+    float xm = log10((1.0 - blackSignal) / gray + nz) * encGain + encOffset;
+
+    ns = relativeExposureToNormalizedSensor(re, EI);
+
+    ns = (ns - blackSignal) / gray + nz;
+
+    if (xm > 1) {
+        // Hermite blending region
+        // Tricky to implement an inverse unless needed. It might be possible to
+        // iteratively solve for a numerical inversion, but is currently not
+        // supported.
+        return 0;
+    } else { // Valid for EI values below 1600
+        if (ns > cut)
+        {
+            out = log10(ns);
+        } 
+        else
+        {
+            out = slope * ns + offset;
+        }
+    }
+
+    return out * encGain + encOffset;
+}
+
+void main(input varying float rIn,
+          input varying float gIn,
+          input varying float bIn,
+          input varying float aIn,
+          output varying float rOut,
+          output varying float gOut,
+          output varying float bOut,
+          output varying float aOut,
+          input uniform float EI = 160.0)
+{
+    float ACES[3] = {rIn, gIn, bIn};
+
+    float lin_AWG3[3] = mult_f3_f33(ACES, AP0_to_AWG3_MAT);
+
+    rOut = relativeExposureToNormalizedLogC3(lin_AWG3[0], EI);
+    gOut = relativeExposureToNormalizedLogC3(lin_AWG3[1], EI);
+    bOut = relativeExposureToNormalizedLogC3(lin_AWG3[2], EI);
+    aOut = aIn;
+}

--- a/arri/CSC.Arri.ACES_to_LogCv3-EI160.ctl
+++ b/arri/CSC.Arri.ACES_to_LogCv3-EI160.ctl
@@ -10,6 +10,7 @@
 
 import "Lib.Academy.Utilities";
 import "Lib.Academy.ColorSpaces";
+import "Lib.Arri.LogC3";
 
 const Chromaticities AP0 = // ACES Primaries from SMPTE ST2065-1
     {
@@ -29,59 +30,7 @@ const float AP0_to_AWG3_MAT[3][3] = calculate_rgb_to_rgb_matrix(AP0,
                                                                 ARRI_ALEXA_WG_PRI,
                                                                 CONE_RESP_MAT_CAT02);
 
-const float nominalEI = 400.0;
-const float blackSignal = 16.0 / 4095.0;
-const float midGraySignal = 0.01;
-const float encodingGain = 500.0 / 1023.0 * 0.525;
-const float encodingOffset = 400.0 / 1023.0;
-const float cut = 1.0 / 9.0;
-const float slope = 1.0 / (cut * log(10.0));
-const float offset = log10(cut) - slope * cut;
-
-float relativeExposureToNormalizedSensor(float re, float EI)
-{
-    return re * (midGraySignal * nominalEI / EI) / 0.18 + blackSignal;
-}
-
-float relativeExposureToNormalizedLogC3(float re, float EI)
-{
-    float nz;
-    float out;
-    float ns;
-    const float gain = EI / nominalEI;
-    const float gray = midGraySignal / gain;
-    const float encGain = (log2(gain) * (0.89 - 1.0) / 3.0 + 1.0) * encodingGain;
-    float encOffset = encodingOffset;
-    for (int i = 0; i < 3; i = i + 1)
-    {
-        nz = ((95.0 / 1023.0 - encOffset) / encGain - offset) / slope;
-        encOffset = encodingOffset - log10(1.0 + nz) * encGain;
-    }
-    float xm = log10((1.0 - blackSignal) / gray + nz) * encGain + encOffset;
-
-    ns = relativeExposureToNormalizedSensor(re, EI);
-
-    ns = (ns - blackSignal) / gray + nz;
-
-    if (xm > 1) {
-        // Hermite blending region
-        // Tricky to implement an inverse unless needed. It might be possible to
-        // iteratively solve for a numerical inversion, but is currently not
-        // supported.
-        return 0;
-    } else { // Valid for EI values below 1600
-        if (ns > cut)
-        {
-            out = log10(ns);
-        } 
-        else
-        {
-            out = slope * ns + offset;
-        }
-    }
-
-    return out * encGain + encOffset;
-}
+const float EI = 160.0;
 
 void main(input varying float rIn,
           input varying float gIn,
@@ -90,8 +39,7 @@ void main(input varying float rIn,
           output varying float rOut,
           output varying float gOut,
           output varying float bOut,
-          output varying float aOut,
-          input uniform float EI = 160.0)
+          output varying float aOut)
 {
     float ACES[3] = {rIn, gIn, bIn};
 

--- a/arri/CSC.Arri.ACES_to_LogCv3-EI160.ctl
+++ b/arri/CSC.Arri.ACES_to_LogCv3-EI160.ctl
@@ -9,26 +9,7 @@
 //
 
 import "Lib.Academy.Utilities";
-import "Lib.Academy.ColorSpaces";
 import "Lib.Arri.LogC3";
-
-const Chromaticities AP0 = // ACES Primaries from SMPTE ST2065-1
-    {
-        {0.73470, 0.26530},
-        {0.00000, 1.00000},
-        {0.00010, -0.07700},
-        {0.32168, 0.33767}};
-
-const Chromaticities ARRI_ALEXA_WG_PRI =
-    {
-        {0.68400, 0.31300},
-        {0.22100, 0.84800},
-        {0.08610, -0.10200},
-        {0.31270, 0.32900}};
-
-const float AP0_to_AWG3_MAT[3][3] = calculate_rgb_to_rgb_matrix(AP0,
-                                                                ARRI_ALEXA_WG_PRI,
-                                                                CONE_RESP_MAT_CAT02);
 
 const float EI = 160.0;
 

--- a/arri/CSC.Arri.ACES_to_LogCv3-EI200.ctl
+++ b/arri/CSC.Arri.ACES_to_LogCv3-EI200.ctl
@@ -10,6 +10,7 @@
 
 import "Lib.Academy.Utilities";
 import "Lib.Academy.ColorSpaces";
+import "Lib.Arri.LogC3";
 
 const Chromaticities AP0 = // ACES Primaries from SMPTE ST2065-1
     {
@@ -29,59 +30,7 @@ const float AP0_to_AWG3_MAT[3][3] = calculate_rgb_to_rgb_matrix(AP0,
                                                                 ARRI_ALEXA_WG_PRI,
                                                                 CONE_RESP_MAT_CAT02);
 
-const float nominalEI = 400.0;
-const float blackSignal = 16.0 / 4095.0;
-const float midGraySignal = 0.01;
-const float encodingGain = 500.0 / 1023.0 * 0.525;
-const float encodingOffset = 400.0 / 1023.0;
-const float cut = 1.0 / 9.0;
-const float slope = 1.0 / (cut * log(10.0));
-const float offset = log10(cut) - slope * cut;
-
-float relativeExposureToNormalizedSensor(float re, float EI)
-{
-    return re * (midGraySignal * nominalEI / EI) / 0.18 + blackSignal;
-}
-
-float relativeExposureToNormalizedLogC3(float re, float EI)
-{
-    float nz;
-    float out;
-    float ns;
-    const float gain = EI / nominalEI;
-    const float gray = midGraySignal / gain;
-    const float encGain = (log2(gain) * (0.89 - 1.0) / 3.0 + 1.0) * encodingGain;
-    float encOffset = encodingOffset;
-    for (int i = 0; i < 3; i = i + 1)
-    {
-        nz = ((95.0 / 1023.0 - encOffset) / encGain - offset) / slope;
-        encOffset = encodingOffset - log10(1.0 + nz) * encGain;
-    }
-    float xm = log10((1.0 - blackSignal) / gray + nz) * encGain + encOffset;
-
-    ns = relativeExposureToNormalizedSensor(re, EI);
-
-    ns = (ns - blackSignal) / gray + nz;
-
-    if (xm > 1) {
-        // Hermite blending region
-        // Tricky to implement an inverse unless needed. It might be possible to
-        // iteratively solve for a numerical inversion, but is currently not
-        // supported.
-        return 0;
-    } else { // Valid for EI values below 1600
-        if (ns > cut)
-        {
-            out = log10(ns);
-        } 
-        else
-        {
-            out = slope * ns + offset;
-        }
-    }
-
-    return out * encGain + encOffset;
-}
+const float EI = 200.0;
 
 void main(input varying float rIn,
           input varying float gIn,
@@ -90,8 +39,7 @@ void main(input varying float rIn,
           output varying float rOut,
           output varying float gOut,
           output varying float bOut,
-          output varying float aOut,
-          input uniform float EI = 200.0)
+          output varying float aOut)
 {
     float ACES[3] = {rIn, gIn, bIn};
 

--- a/arri/CSC.Arri.ACES_to_LogCv3-EI200.ctl
+++ b/arri/CSC.Arri.ACES_to_LogCv3-EI200.ctl
@@ -1,0 +1,104 @@
+// <ACEStransformID>urn:ampas:aces:transformId:v2.0:CSC.Arri.ACES_to_LogC3-EI200.a2.v1</ACEStransformID>
+// <ACESuserName>ACES2065-1 to ARRI LogC3 EI200</ACESuserName>
+
+//
+// ACES Color Space Conversion - ACES2065-1 to Arri LogC3 EI200
+//
+// converts ACES2065-1 (AP0 w/ linear encoding) to
+//          Arri LogC3 EI200
+//
+
+import "Lib.Academy.Utilities";
+import "Lib.Academy.ColorSpaces";
+
+const Chromaticities AP0 = // ACES Primaries from SMPTE ST2065-1
+    {
+        {0.73470, 0.26530},
+        {0.00000, 1.00000},
+        {0.00010, -0.07700},
+        {0.32168, 0.33767}};
+
+const Chromaticities ARRI_ALEXA_WG_PRI =
+    {
+        {0.68400, 0.31300},
+        {0.22100, 0.84800},
+        {0.08610, -0.10200},
+        {0.31270, 0.32900}};
+
+const float AP0_to_AWG3_MAT[3][3] = calculate_rgb_to_rgb_matrix(AP0,
+                                                                ARRI_ALEXA_WG_PRI,
+                                                                CONE_RESP_MAT_CAT02);
+
+const float nominalEI = 400.0;
+const float blackSignal = 16.0 / 4095.0;
+const float midGraySignal = 0.01;
+const float encodingGain = 500.0 / 1023.0 * 0.525;
+const float encodingOffset = 400.0 / 1023.0;
+const float cut = 1.0 / 9.0;
+const float slope = 1.0 / (cut * log(10.0));
+const float offset = log10(cut) - slope * cut;
+
+float relativeExposureToNormalizedSensor(float re, float EI)
+{
+    return re * (midGraySignal * nominalEI / EI) / 0.18 + blackSignal;
+}
+
+float relativeExposureToNormalizedLogC3(float re, float EI)
+{
+    float nz;
+    float out;
+    float ns;
+    const float gain = EI / nominalEI;
+    const float gray = midGraySignal / gain;
+    const float encGain = (log2(gain) * (0.89 - 1.0) / 3.0 + 1.0) * encodingGain;
+    float encOffset = encodingOffset;
+    for (int i = 0; i < 3; i = i + 1)
+    {
+        nz = ((95.0 / 1023.0 - encOffset) / encGain - offset) / slope;
+        encOffset = encodingOffset - log10(1.0 + nz) * encGain;
+    }
+    float xm = log10((1.0 - blackSignal) / gray + nz) * encGain + encOffset;
+
+    ns = relativeExposureToNormalizedSensor(re, EI);
+
+    ns = (ns - blackSignal) / gray + nz;
+
+    if (xm > 1) {
+        // Hermite blending region
+        // Tricky to implement an inverse unless needed. It might be possible to
+        // iteratively solve for a numerical inversion, but is currently not
+        // supported.
+        return 0;
+    } else { // Valid for EI values below 1600
+        if (ns > cut)
+        {
+            out = log10(ns);
+        } 
+        else
+        {
+            out = slope * ns + offset;
+        }
+    }
+
+    return out * encGain + encOffset;
+}
+
+void main(input varying float rIn,
+          input varying float gIn,
+          input varying float bIn,
+          input varying float aIn,
+          output varying float rOut,
+          output varying float gOut,
+          output varying float bOut,
+          output varying float aOut,
+          input uniform float EI = 200.0)
+{
+    float ACES[3] = {rIn, gIn, bIn};
+
+    float lin_AWG3[3] = mult_f3_f33(ACES, AP0_to_AWG3_MAT);
+
+    rOut = relativeExposureToNormalizedLogC3(lin_AWG3[0], EI);
+    gOut = relativeExposureToNormalizedLogC3(lin_AWG3[1], EI);
+    bOut = relativeExposureToNormalizedLogC3(lin_AWG3[2], EI);
+    aOut = aIn;
+}

--- a/arri/CSC.Arri.ACES_to_LogCv3-EI200.ctl
+++ b/arri/CSC.Arri.ACES_to_LogCv3-EI200.ctl
@@ -9,26 +9,7 @@
 //
 
 import "Lib.Academy.Utilities";
-import "Lib.Academy.ColorSpaces";
 import "Lib.Arri.LogC3";
-
-const Chromaticities AP0 = // ACES Primaries from SMPTE ST2065-1
-    {
-        {0.73470, 0.26530},
-        {0.00000, 1.00000},
-        {0.00010, -0.07700},
-        {0.32168, 0.33767}};
-
-const Chromaticities ARRI_ALEXA_WG_PRI =
-    {
-        {0.68400, 0.31300},
-        {0.22100, 0.84800},
-        {0.08610, -0.10200},
-        {0.31270, 0.32900}};
-
-const float AP0_to_AWG3_MAT[3][3] = calculate_rgb_to_rgb_matrix(AP0,
-                                                                ARRI_ALEXA_WG_PRI,
-                                                                CONE_RESP_MAT_CAT02);
 
 const float EI = 200.0;
 

--- a/arri/CSC.Arri.ACES_to_LogCv3-EI250.ctl
+++ b/arri/CSC.Arri.ACES_to_LogCv3-EI250.ctl
@@ -1,0 +1,104 @@
+// <ACEStransformID>urn:ampas:aces:transformId:v2.0:CSC.Arri.ACES_to_LogC3-EI250.a2.v1</ACEStransformID>
+// <ACESuserName>ACES2065-1 to ARRI LogC3 EI250</ACESuserName>
+
+//
+// ACES Color Space Conversion - ACES2065-1 to Arri LogC3 EI250
+//
+// converts ACES2065-1 (AP0 w/ linear encoding) to
+//          Arri LogC3 EI250
+//
+
+import "Lib.Academy.Utilities";
+import "Lib.Academy.ColorSpaces";
+
+const Chromaticities AP0 = // ACES Primaries from SMPTE ST2065-1
+    {
+        {0.73470, 0.26530},
+        {0.00000, 1.00000},
+        {0.00010, -0.07700},
+        {0.32168, 0.33767}};
+
+const Chromaticities ARRI_ALEXA_WG_PRI =
+    {
+        {0.68400, 0.31300},
+        {0.22100, 0.84800},
+        {0.08610, -0.10200},
+        {0.31270, 0.32900}};
+
+const float AP0_to_AWG3_MAT[3][3] = calculate_rgb_to_rgb_matrix(AP0,
+                                                                ARRI_ALEXA_WG_PRI,
+                                                                CONE_RESP_MAT_CAT02);
+
+const float nominalEI = 400.0;
+const float blackSignal = 16.0 / 4095.0;
+const float midGraySignal = 0.01;
+const float encodingGain = 500.0 / 1023.0 * 0.525;
+const float encodingOffset = 400.0 / 1023.0;
+const float cut = 1.0 / 9.0;
+const float slope = 1.0 / (cut * log(10.0));
+const float offset = log10(cut) - slope * cut;
+
+float relativeExposureToNormalizedSensor(float re, float EI)
+{
+    return re * (midGraySignal * nominalEI / EI) / 0.18 + blackSignal;
+}
+
+float relativeExposureToNormalizedLogC3(float re, float EI)
+{
+    float nz;
+    float out;
+    float ns;
+    const float gain = EI / nominalEI;
+    const float gray = midGraySignal / gain;
+    const float encGain = (log2(gain) * (0.89 - 1.0) / 3.0 + 1.0) * encodingGain;
+    float encOffset = encodingOffset;
+    for (int i = 0; i < 3; i = i + 1)
+    {
+        nz = ((95.0 / 1023.0 - encOffset) / encGain - offset) / slope;
+        encOffset = encodingOffset - log10(1.0 + nz) * encGain;
+    }
+    float xm = log10((1.0 - blackSignal) / gray + nz) * encGain + encOffset;
+
+    ns = relativeExposureToNormalizedSensor(re, EI);
+
+    ns = (ns - blackSignal) / gray + nz;
+
+    if (xm > 1) {
+        // Hermite blending region
+        // Tricky to implement an inverse unless needed. It might be possible to
+        // iteratively solve for a numerical inversion, but is currently not
+        // supported.
+        return 0;
+    } else { // Valid for EI values below 1600
+        if (ns > cut)
+        {
+            out = log10(ns);
+        } 
+        else
+        {
+            out = slope * ns + offset;
+        }
+    }
+
+    return out * encGain + encOffset;
+}
+
+void main(input varying float rIn,
+          input varying float gIn,
+          input varying float bIn,
+          input varying float aIn,
+          output varying float rOut,
+          output varying float gOut,
+          output varying float bOut,
+          output varying float aOut,
+          input uniform float EI = 250.0)
+{
+    float ACES[3] = {rIn, gIn, bIn};
+
+    float lin_AWG3[3] = mult_f3_f33(ACES, AP0_to_AWG3_MAT);
+
+    rOut = relativeExposureToNormalizedLogC3(lin_AWG3[0], EI);
+    gOut = relativeExposureToNormalizedLogC3(lin_AWG3[1], EI);
+    bOut = relativeExposureToNormalizedLogC3(lin_AWG3[2], EI);
+    aOut = aIn;
+}

--- a/arri/CSC.Arri.ACES_to_LogCv3-EI250.ctl
+++ b/arri/CSC.Arri.ACES_to_LogCv3-EI250.ctl
@@ -10,6 +10,7 @@
 
 import "Lib.Academy.Utilities";
 import "Lib.Academy.ColorSpaces";
+import "Lib.Arri.LogC3";
 
 const Chromaticities AP0 = // ACES Primaries from SMPTE ST2065-1
     {
@@ -29,59 +30,7 @@ const float AP0_to_AWG3_MAT[3][3] = calculate_rgb_to_rgb_matrix(AP0,
                                                                 ARRI_ALEXA_WG_PRI,
                                                                 CONE_RESP_MAT_CAT02);
 
-const float nominalEI = 400.0;
-const float blackSignal = 16.0 / 4095.0;
-const float midGraySignal = 0.01;
-const float encodingGain = 500.0 / 1023.0 * 0.525;
-const float encodingOffset = 400.0 / 1023.0;
-const float cut = 1.0 / 9.0;
-const float slope = 1.0 / (cut * log(10.0));
-const float offset = log10(cut) - slope * cut;
-
-float relativeExposureToNormalizedSensor(float re, float EI)
-{
-    return re * (midGraySignal * nominalEI / EI) / 0.18 + blackSignal;
-}
-
-float relativeExposureToNormalizedLogC3(float re, float EI)
-{
-    float nz;
-    float out;
-    float ns;
-    const float gain = EI / nominalEI;
-    const float gray = midGraySignal / gain;
-    const float encGain = (log2(gain) * (0.89 - 1.0) / 3.0 + 1.0) * encodingGain;
-    float encOffset = encodingOffset;
-    for (int i = 0; i < 3; i = i + 1)
-    {
-        nz = ((95.0 / 1023.0 - encOffset) / encGain - offset) / slope;
-        encOffset = encodingOffset - log10(1.0 + nz) * encGain;
-    }
-    float xm = log10((1.0 - blackSignal) / gray + nz) * encGain + encOffset;
-
-    ns = relativeExposureToNormalizedSensor(re, EI);
-
-    ns = (ns - blackSignal) / gray + nz;
-
-    if (xm > 1) {
-        // Hermite blending region
-        // Tricky to implement an inverse unless needed. It might be possible to
-        // iteratively solve for a numerical inversion, but is currently not
-        // supported.
-        return 0;
-    } else { // Valid for EI values below 1600
-        if (ns > cut)
-        {
-            out = log10(ns);
-        } 
-        else
-        {
-            out = slope * ns + offset;
-        }
-    }
-
-    return out * encGain + encOffset;
-}
+const float EI = 250.0;
 
 void main(input varying float rIn,
           input varying float gIn,
@@ -90,8 +39,7 @@ void main(input varying float rIn,
           output varying float rOut,
           output varying float gOut,
           output varying float bOut,
-          output varying float aOut,
-          input uniform float EI = 250.0)
+          output varying float aOut)
 {
     float ACES[3] = {rIn, gIn, bIn};
 

--- a/arri/CSC.Arri.ACES_to_LogCv3-EI250.ctl
+++ b/arri/CSC.Arri.ACES_to_LogCv3-EI250.ctl
@@ -9,26 +9,7 @@
 //
 
 import "Lib.Academy.Utilities";
-import "Lib.Academy.ColorSpaces";
 import "Lib.Arri.LogC3";
-
-const Chromaticities AP0 = // ACES Primaries from SMPTE ST2065-1
-    {
-        {0.73470, 0.26530},
-        {0.00000, 1.00000},
-        {0.00010, -0.07700},
-        {0.32168, 0.33767}};
-
-const Chromaticities ARRI_ALEXA_WG_PRI =
-    {
-        {0.68400, 0.31300},
-        {0.22100, 0.84800},
-        {0.08610, -0.10200},
-        {0.31270, 0.32900}};
-
-const float AP0_to_AWG3_MAT[3][3] = calculate_rgb_to_rgb_matrix(AP0,
-                                                                ARRI_ALEXA_WG_PRI,
-                                                                CONE_RESP_MAT_CAT02);
 
 const float EI = 250.0;
 

--- a/arri/CSC.Arri.ACES_to_LogCv3-EI320.ctl
+++ b/arri/CSC.Arri.ACES_to_LogCv3-EI320.ctl
@@ -10,6 +10,7 @@
 
 import "Lib.Academy.Utilities";
 import "Lib.Academy.ColorSpaces";
+import "Lib.Arri.LogC3";
 
 const Chromaticities AP0 = // ACES Primaries from SMPTE ST2065-1
     {
@@ -29,59 +30,7 @@ const float AP0_to_AWG3_MAT[3][3] = calculate_rgb_to_rgb_matrix(AP0,
                                                                 ARRI_ALEXA_WG_PRI,
                                                                 CONE_RESP_MAT_CAT02);
 
-const float nominalEI = 400.0;
-const float blackSignal = 16.0 / 4095.0;
-const float midGraySignal = 0.01;
-const float encodingGain = 500.0 / 1023.0 * 0.525;
-const float encodingOffset = 400.0 / 1023.0;
-const float cut = 1.0 / 9.0;
-const float slope = 1.0 / (cut * log(10.0));
-const float offset = log10(cut) - slope * cut;
-
-float relativeExposureToNormalizedSensor(float re, float EI)
-{
-    return re * (midGraySignal * nominalEI / EI) / 0.18 + blackSignal;
-}
-
-float relativeExposureToNormalizedLogC3(float re, float EI)
-{
-    float nz;
-    float out;
-    float ns;
-    const float gain = EI / nominalEI;
-    const float gray = midGraySignal / gain;
-    const float encGain = (log2(gain) * (0.89 - 1.0) / 3.0 + 1.0) * encodingGain;
-    float encOffset = encodingOffset;
-    for (int i = 0; i < 3; i = i + 1)
-    {
-        nz = ((95.0 / 1023.0 - encOffset) / encGain - offset) / slope;
-        encOffset = encodingOffset - log10(1.0 + nz) * encGain;
-    }
-    float xm = log10((1.0 - blackSignal) / gray + nz) * encGain + encOffset;
-
-    ns = relativeExposureToNormalizedSensor(re, EI);
-
-    ns = (ns - blackSignal) / gray + nz;
-
-    if (xm > 1) {
-        // Hermite blending region
-        // Tricky to implement an inverse unless needed. It might be possible to
-        // iteratively solve for a numerical inversion, but is currently not
-        // supported.
-        return 0;
-    } else { // Valid for EI values below 1600
-        if (ns > cut)
-        {
-            out = log10(ns);
-        } 
-        else
-        {
-            out = slope * ns + offset;
-        }
-    }
-
-    return out * encGain + encOffset;
-}
+const float EI = 320.0;
 
 void main(input varying float rIn,
           input varying float gIn,
@@ -90,8 +39,7 @@ void main(input varying float rIn,
           output varying float rOut,
           output varying float gOut,
           output varying float bOut,
-          output varying float aOut,
-          input uniform float EI = 320.0)
+          output varying float aOut)
 {
     float ACES[3] = {rIn, gIn, bIn};
 

--- a/arri/CSC.Arri.ACES_to_LogCv3-EI320.ctl
+++ b/arri/CSC.Arri.ACES_to_LogCv3-EI320.ctl
@@ -1,0 +1,104 @@
+// <ACEStransformID>urn:ampas:aces:transformId:v2.0:CSC.Arri.ACES_to_LogC3-EI320.a2.v1</ACEStransformID>
+// <ACESuserName>ACES2065-1 to ARRI LogC3 EI320</ACESuserName>
+
+//
+// ACES Color Space Conversion - ACES2065-1 to Arri LogC3 EI320
+//
+// converts ACES2065-1 (AP0 w/ linear encoding) to
+//          Arri LogC3 EI320
+//
+
+import "Lib.Academy.Utilities";
+import "Lib.Academy.ColorSpaces";
+
+const Chromaticities AP0 = // ACES Primaries from SMPTE ST2065-1
+    {
+        {0.73470, 0.26530},
+        {0.00000, 1.00000},
+        {0.00010, -0.07700},
+        {0.32168, 0.33767}};
+
+const Chromaticities ARRI_ALEXA_WG_PRI =
+    {
+        {0.68400, 0.31300},
+        {0.22100, 0.84800},
+        {0.08610, -0.10200},
+        {0.31270, 0.32900}};
+
+const float AP0_to_AWG3_MAT[3][3] = calculate_rgb_to_rgb_matrix(AP0,
+                                                                ARRI_ALEXA_WG_PRI,
+                                                                CONE_RESP_MAT_CAT02);
+
+const float nominalEI = 400.0;
+const float blackSignal = 16.0 / 4095.0;
+const float midGraySignal = 0.01;
+const float encodingGain = 500.0 / 1023.0 * 0.525;
+const float encodingOffset = 400.0 / 1023.0;
+const float cut = 1.0 / 9.0;
+const float slope = 1.0 / (cut * log(10.0));
+const float offset = log10(cut) - slope * cut;
+
+float relativeExposureToNormalizedSensor(float re, float EI)
+{
+    return re * (midGraySignal * nominalEI / EI) / 0.18 + blackSignal;
+}
+
+float relativeExposureToNormalizedLogC3(float re, float EI)
+{
+    float nz;
+    float out;
+    float ns;
+    const float gain = EI / nominalEI;
+    const float gray = midGraySignal / gain;
+    const float encGain = (log2(gain) * (0.89 - 1.0) / 3.0 + 1.0) * encodingGain;
+    float encOffset = encodingOffset;
+    for (int i = 0; i < 3; i = i + 1)
+    {
+        nz = ((95.0 / 1023.0 - encOffset) / encGain - offset) / slope;
+        encOffset = encodingOffset - log10(1.0 + nz) * encGain;
+    }
+    float xm = log10((1.0 - blackSignal) / gray + nz) * encGain + encOffset;
+
+    ns = relativeExposureToNormalizedSensor(re, EI);
+
+    ns = (ns - blackSignal) / gray + nz;
+
+    if (xm > 1) {
+        // Hermite blending region
+        // Tricky to implement an inverse unless needed. It might be possible to
+        // iteratively solve for a numerical inversion, but is currently not
+        // supported.
+        return 0;
+    } else { // Valid for EI values below 1600
+        if (ns > cut)
+        {
+            out = log10(ns);
+        } 
+        else
+        {
+            out = slope * ns + offset;
+        }
+    }
+
+    return out * encGain + encOffset;
+}
+
+void main(input varying float rIn,
+          input varying float gIn,
+          input varying float bIn,
+          input varying float aIn,
+          output varying float rOut,
+          output varying float gOut,
+          output varying float bOut,
+          output varying float aOut,
+          input uniform float EI = 320.0)
+{
+    float ACES[3] = {rIn, gIn, bIn};
+
+    float lin_AWG3[3] = mult_f3_f33(ACES, AP0_to_AWG3_MAT);
+
+    rOut = relativeExposureToNormalizedLogC3(lin_AWG3[0], EI);
+    gOut = relativeExposureToNormalizedLogC3(lin_AWG3[1], EI);
+    bOut = relativeExposureToNormalizedLogC3(lin_AWG3[2], EI);
+    aOut = aIn;
+}

--- a/arri/CSC.Arri.ACES_to_LogCv3-EI320.ctl
+++ b/arri/CSC.Arri.ACES_to_LogCv3-EI320.ctl
@@ -9,26 +9,7 @@
 //
 
 import "Lib.Academy.Utilities";
-import "Lib.Academy.ColorSpaces";
 import "Lib.Arri.LogC3";
-
-const Chromaticities AP0 = // ACES Primaries from SMPTE ST2065-1
-    {
-        {0.73470, 0.26530},
-        {0.00000, 1.00000},
-        {0.00010, -0.07700},
-        {0.32168, 0.33767}};
-
-const Chromaticities ARRI_ALEXA_WG_PRI =
-    {
-        {0.68400, 0.31300},
-        {0.22100, 0.84800},
-        {0.08610, -0.10200},
-        {0.31270, 0.32900}};
-
-const float AP0_to_AWG3_MAT[3][3] = calculate_rgb_to_rgb_matrix(AP0,
-                                                                ARRI_ALEXA_WG_PRI,
-                                                                CONE_RESP_MAT_CAT02);
 
 const float EI = 320.0;
 

--- a/arri/CSC.Arri.ACES_to_LogCv3-EI400.ctl
+++ b/arri/CSC.Arri.ACES_to_LogCv3-EI400.ctl
@@ -10,6 +10,7 @@
 
 import "Lib.Academy.Utilities";
 import "Lib.Academy.ColorSpaces";
+import "Lib.Arri.LogC3";
 
 const Chromaticities AP0 = // ACES Primaries from SMPTE ST2065-1
     {
@@ -29,59 +30,7 @@ const float AP0_to_AWG3_MAT[3][3] = calculate_rgb_to_rgb_matrix(AP0,
                                                                 ARRI_ALEXA_WG_PRI,
                                                                 CONE_RESP_MAT_CAT02);
 
-const float nominalEI = 400.0;
-const float blackSignal = 16.0 / 4095.0;
-const float midGraySignal = 0.01;
-const float encodingGain = 500.0 / 1023.0 * 0.525;
-const float encodingOffset = 400.0 / 1023.0;
-const float cut = 1.0 / 9.0;
-const float slope = 1.0 / (cut * log(10.0));
-const float offset = log10(cut) - slope * cut;
-
-float relativeExposureToNormalizedSensor(float re, float EI)
-{
-    return re * (midGraySignal * nominalEI / EI) / 0.18 + blackSignal;
-}
-
-float relativeExposureToNormalizedLogC3(float re, float EI)
-{
-    float nz;
-    float out;
-    float ns;
-    const float gain = EI / nominalEI;
-    const float gray = midGraySignal / gain;
-    const float encGain = (log2(gain) * (0.89 - 1.0) / 3.0 + 1.0) * encodingGain;
-    float encOffset = encodingOffset;
-    for (int i = 0; i < 3; i = i + 1)
-    {
-        nz = ((95.0 / 1023.0 - encOffset) / encGain - offset) / slope;
-        encOffset = encodingOffset - log10(1.0 + nz) * encGain;
-    }
-    float xm = log10((1.0 - blackSignal) / gray + nz) * encGain + encOffset;
-
-    ns = relativeExposureToNormalizedSensor(re, EI);
-
-    ns = (ns - blackSignal) / gray + nz;
-
-    if (xm > 1) {
-        // Hermite blending region
-        // Tricky to implement an inverse unless needed. It might be possible to
-        // iteratively solve for a numerical inversion, but is currently not
-        // supported.
-        return 0;
-    } else { // Valid for EI values below 1600
-        if (ns > cut)
-        {
-            out = log10(ns);
-        } 
-        else
-        {
-            out = slope * ns + offset;
-        }
-    }
-
-    return out * encGain + encOffset;
-}
+const float EI = 400.0;
 
 void main(input varying float rIn,
           input varying float gIn,
@@ -90,8 +39,7 @@ void main(input varying float rIn,
           output varying float rOut,
           output varying float gOut,
           output varying float bOut,
-          output varying float aOut,
-          input uniform float EI = 400.0)
+          output varying float aOut)
 {
     float ACES[3] = {rIn, gIn, bIn};
 

--- a/arri/CSC.Arri.ACES_to_LogCv3-EI400.ctl
+++ b/arri/CSC.Arri.ACES_to_LogCv3-EI400.ctl
@@ -1,0 +1,104 @@
+// <ACEStransformID>urn:ampas:aces:transformId:v2.0:CSC.Arri.ACES_to_LogC3-EI400.a2.v1</ACEStransformID>
+// <ACESuserName>ACES2065-1 to ARRI LogC3 EI400</ACESuserName>
+
+//
+// ACES Color Space Conversion - ACES2065-1 to Arri LogC3 EI400
+//
+// converts ACES2065-1 (AP0 w/ linear encoding) to
+//          Arri LogC3 EI400
+//
+
+import "Lib.Academy.Utilities";
+import "Lib.Academy.ColorSpaces";
+
+const Chromaticities AP0 = // ACES Primaries from SMPTE ST2065-1
+    {
+        {0.73470, 0.26530},
+        {0.00000, 1.00000},
+        {0.00010, -0.07700},
+        {0.32168, 0.33767}};
+
+const Chromaticities ARRI_ALEXA_WG_PRI =
+    {
+        {0.68400, 0.31300},
+        {0.22100, 0.84800},
+        {0.08610, -0.10200},
+        {0.31270, 0.32900}};
+
+const float AP0_to_AWG3_MAT[3][3] = calculate_rgb_to_rgb_matrix(AP0,
+                                                                ARRI_ALEXA_WG_PRI,
+                                                                CONE_RESP_MAT_CAT02);
+
+const float nominalEI = 400.0;
+const float blackSignal = 16.0 / 4095.0;
+const float midGraySignal = 0.01;
+const float encodingGain = 500.0 / 1023.0 * 0.525;
+const float encodingOffset = 400.0 / 1023.0;
+const float cut = 1.0 / 9.0;
+const float slope = 1.0 / (cut * log(10.0));
+const float offset = log10(cut) - slope * cut;
+
+float relativeExposureToNormalizedSensor(float re, float EI)
+{
+    return re * (midGraySignal * nominalEI / EI) / 0.18 + blackSignal;
+}
+
+float relativeExposureToNormalizedLogC3(float re, float EI)
+{
+    float nz;
+    float out;
+    float ns;
+    const float gain = EI / nominalEI;
+    const float gray = midGraySignal / gain;
+    const float encGain = (log2(gain) * (0.89 - 1.0) / 3.0 + 1.0) * encodingGain;
+    float encOffset = encodingOffset;
+    for (int i = 0; i < 3; i = i + 1)
+    {
+        nz = ((95.0 / 1023.0 - encOffset) / encGain - offset) / slope;
+        encOffset = encodingOffset - log10(1.0 + nz) * encGain;
+    }
+    float xm = log10((1.0 - blackSignal) / gray + nz) * encGain + encOffset;
+
+    ns = relativeExposureToNormalizedSensor(re, EI);
+
+    ns = (ns - blackSignal) / gray + nz;
+
+    if (xm > 1) {
+        // Hermite blending region
+        // Tricky to implement an inverse unless needed. It might be possible to
+        // iteratively solve for a numerical inversion, but is currently not
+        // supported.
+        return 0;
+    } else { // Valid for EI values below 1600
+        if (ns > cut)
+        {
+            out = log10(ns);
+        } 
+        else
+        {
+            out = slope * ns + offset;
+        }
+    }
+
+    return out * encGain + encOffset;
+}
+
+void main(input varying float rIn,
+          input varying float gIn,
+          input varying float bIn,
+          input varying float aIn,
+          output varying float rOut,
+          output varying float gOut,
+          output varying float bOut,
+          output varying float aOut,
+          input uniform float EI = 400.0)
+{
+    float ACES[3] = {rIn, gIn, bIn};
+
+    float lin_AWG3[3] = mult_f3_f33(ACES, AP0_to_AWG3_MAT);
+
+    rOut = relativeExposureToNormalizedLogC3(lin_AWG3[0], EI);
+    gOut = relativeExposureToNormalizedLogC3(lin_AWG3[1], EI);
+    bOut = relativeExposureToNormalizedLogC3(lin_AWG3[2], EI);
+    aOut = aIn;
+}

--- a/arri/CSC.Arri.ACES_to_LogCv3-EI400.ctl
+++ b/arri/CSC.Arri.ACES_to_LogCv3-EI400.ctl
@@ -9,26 +9,7 @@
 //
 
 import "Lib.Academy.Utilities";
-import "Lib.Academy.ColorSpaces";
 import "Lib.Arri.LogC3";
-
-const Chromaticities AP0 = // ACES Primaries from SMPTE ST2065-1
-    {
-        {0.73470, 0.26530},
-        {0.00000, 1.00000},
-        {0.00010, -0.07700},
-        {0.32168, 0.33767}};
-
-const Chromaticities ARRI_ALEXA_WG_PRI =
-    {
-        {0.68400, 0.31300},
-        {0.22100, 0.84800},
-        {0.08610, -0.10200},
-        {0.31270, 0.32900}};
-
-const float AP0_to_AWG3_MAT[3][3] = calculate_rgb_to_rgb_matrix(AP0,
-                                                                ARRI_ALEXA_WG_PRI,
-                                                                CONE_RESP_MAT_CAT02);
 
 const float EI = 400.0;
 

--- a/arri/CSC.Arri.ACES_to_LogCv3-EI500.ctl
+++ b/arri/CSC.Arri.ACES_to_LogCv3-EI500.ctl
@@ -1,0 +1,104 @@
+// <ACEStransformID>urn:ampas:aces:transformId:v2.0:CSC.Arri.ACES_to_LogC3-EI500.a2.v1</ACEStransformID>
+// <ACESuserName>ACES2065-1 to ARRI LogC3 EI500</ACESuserName>
+
+//
+// ACES Color Space Conversion - ACES2065-1 to Arri LogC3 EI500
+//
+// converts ACES2065-1 (AP0 w/ linear encoding) to
+//          Arri LogC3 EI500
+//
+
+import "Lib.Academy.Utilities";
+import "Lib.Academy.ColorSpaces";
+
+const Chromaticities AP0 = // ACES Primaries from SMPTE ST2065-1
+    {
+        {0.73470, 0.26530},
+        {0.00000, 1.00000},
+        {0.00010, -0.07700},
+        {0.32168, 0.33767}};
+
+const Chromaticities ARRI_ALEXA_WG_PRI =
+    {
+        {0.68400, 0.31300},
+        {0.22100, 0.84800},
+        {0.08610, -0.10200},
+        {0.31270, 0.32900}};
+
+const float AP0_to_AWG3_MAT[3][3] = calculate_rgb_to_rgb_matrix(AP0,
+                                                                ARRI_ALEXA_WG_PRI,
+                                                                CONE_RESP_MAT_CAT02);
+
+const float nominalEI = 400.0;
+const float blackSignal = 16.0 / 4095.0;
+const float midGraySignal = 0.01;
+const float encodingGain = 500.0 / 1023.0 * 0.525;
+const float encodingOffset = 400.0 / 1023.0;
+const float cut = 1.0 / 9.0;
+const float slope = 1.0 / (cut * log(10.0));
+const float offset = log10(cut) - slope * cut;
+
+float relativeExposureToNormalizedSensor(float re, float EI)
+{
+    return re * (midGraySignal * nominalEI / EI) / 0.18 + blackSignal;
+}
+
+float relativeExposureToNormalizedLogC3(float re, float EI)
+{
+    float nz;
+    float out;
+    float ns;
+    const float gain = EI / nominalEI;
+    const float gray = midGraySignal / gain;
+    const float encGain = (log2(gain) * (0.89 - 1.0) / 3.0 + 1.0) * encodingGain;
+    float encOffset = encodingOffset;
+    for (int i = 0; i < 3; i = i + 1)
+    {
+        nz = ((95.0 / 1023.0 - encOffset) / encGain - offset) / slope;
+        encOffset = encodingOffset - log10(1.0 + nz) * encGain;
+    }
+    float xm = log10((1.0 - blackSignal) / gray + nz) * encGain + encOffset;
+
+    ns = relativeExposureToNormalizedSensor(re, EI);
+
+    ns = (ns - blackSignal) / gray + nz;
+
+    if (xm > 1) {
+        // Hermite blending region
+        // Tricky to implement an inverse unless needed. It might be possible to
+        // iteratively solve for a numerical inversion, but is currently not
+        // supported.
+        return 0;
+    } else { // Valid for EI values below 1600
+        if (ns > cut)
+        {
+            out = log10(ns);
+        } 
+        else
+        {
+            out = slope * ns + offset;
+        }
+    }
+
+    return out * encGain + encOffset;
+}
+
+void main(input varying float rIn,
+          input varying float gIn,
+          input varying float bIn,
+          input varying float aIn,
+          output varying float rOut,
+          output varying float gOut,
+          output varying float bOut,
+          output varying float aOut,
+          input uniform float EI = 500.0)
+{
+    float ACES[3] = {rIn, gIn, bIn};
+
+    float lin_AWG3[3] = mult_f3_f33(ACES, AP0_to_AWG3_MAT);
+
+    rOut = relativeExposureToNormalizedLogC3(lin_AWG3[0], EI);
+    gOut = relativeExposureToNormalizedLogC3(lin_AWG3[1], EI);
+    bOut = relativeExposureToNormalizedLogC3(lin_AWG3[2], EI);
+    aOut = aIn;
+}

--- a/arri/CSC.Arri.ACES_to_LogCv3-EI500.ctl
+++ b/arri/CSC.Arri.ACES_to_LogCv3-EI500.ctl
@@ -10,6 +10,7 @@
 
 import "Lib.Academy.Utilities";
 import "Lib.Academy.ColorSpaces";
+import "Lib.Arri.LogC3";
 
 const Chromaticities AP0 = // ACES Primaries from SMPTE ST2065-1
     {
@@ -29,59 +30,7 @@ const float AP0_to_AWG3_MAT[3][3] = calculate_rgb_to_rgb_matrix(AP0,
                                                                 ARRI_ALEXA_WG_PRI,
                                                                 CONE_RESP_MAT_CAT02);
 
-const float nominalEI = 400.0;
-const float blackSignal = 16.0 / 4095.0;
-const float midGraySignal = 0.01;
-const float encodingGain = 500.0 / 1023.0 * 0.525;
-const float encodingOffset = 400.0 / 1023.0;
-const float cut = 1.0 / 9.0;
-const float slope = 1.0 / (cut * log(10.0));
-const float offset = log10(cut) - slope * cut;
-
-float relativeExposureToNormalizedSensor(float re, float EI)
-{
-    return re * (midGraySignal * nominalEI / EI) / 0.18 + blackSignal;
-}
-
-float relativeExposureToNormalizedLogC3(float re, float EI)
-{
-    float nz;
-    float out;
-    float ns;
-    const float gain = EI / nominalEI;
-    const float gray = midGraySignal / gain;
-    const float encGain = (log2(gain) * (0.89 - 1.0) / 3.0 + 1.0) * encodingGain;
-    float encOffset = encodingOffset;
-    for (int i = 0; i < 3; i = i + 1)
-    {
-        nz = ((95.0 / 1023.0 - encOffset) / encGain - offset) / slope;
-        encOffset = encodingOffset - log10(1.0 + nz) * encGain;
-    }
-    float xm = log10((1.0 - blackSignal) / gray + nz) * encGain + encOffset;
-
-    ns = relativeExposureToNormalizedSensor(re, EI);
-
-    ns = (ns - blackSignal) / gray + nz;
-
-    if (xm > 1) {
-        // Hermite blending region
-        // Tricky to implement an inverse unless needed. It might be possible to
-        // iteratively solve for a numerical inversion, but is currently not
-        // supported.
-        return 0;
-    } else { // Valid for EI values below 1600
-        if (ns > cut)
-        {
-            out = log10(ns);
-        } 
-        else
-        {
-            out = slope * ns + offset;
-        }
-    }
-
-    return out * encGain + encOffset;
-}
+const float EI = 500.0;
 
 void main(input varying float rIn,
           input varying float gIn,
@@ -90,8 +39,7 @@ void main(input varying float rIn,
           output varying float rOut,
           output varying float gOut,
           output varying float bOut,
-          output varying float aOut,
-          input uniform float EI = 500.0)
+          output varying float aOut)
 {
     float ACES[3] = {rIn, gIn, bIn};
 

--- a/arri/CSC.Arri.ACES_to_LogCv3-EI500.ctl
+++ b/arri/CSC.Arri.ACES_to_LogCv3-EI500.ctl
@@ -9,26 +9,7 @@
 //
 
 import "Lib.Academy.Utilities";
-import "Lib.Academy.ColorSpaces";
 import "Lib.Arri.LogC3";
-
-const Chromaticities AP0 = // ACES Primaries from SMPTE ST2065-1
-    {
-        {0.73470, 0.26530},
-        {0.00000, 1.00000},
-        {0.00010, -0.07700},
-        {0.32168, 0.33767}};
-
-const Chromaticities ARRI_ALEXA_WG_PRI =
-    {
-        {0.68400, 0.31300},
-        {0.22100, 0.84800},
-        {0.08610, -0.10200},
-        {0.31270, 0.32900}};
-
-const float AP0_to_AWG3_MAT[3][3] = calculate_rgb_to_rgb_matrix(AP0,
-                                                                ARRI_ALEXA_WG_PRI,
-                                                                CONE_RESP_MAT_CAT02);
 
 const float EI = 500.0;
 

--- a/arri/CSC.Arri.ACES_to_LogCv3-EI640.ctl
+++ b/arri/CSC.Arri.ACES_to_LogCv3-EI640.ctl
@@ -1,0 +1,104 @@
+// <ACEStransformID>urn:ampas:aces:transformId:v2.0:CSC.Arri.ACES_to_LogC3-EI640.a2.v1</ACEStransformID>
+// <ACESuserName>ACES2065-1 to ARRI LogC3 EI640</ACESuserName>
+
+//
+// ACES Color Space Conversion - ACES2065-1 to Arri LogC3 EI640
+//
+// converts ACES2065-1 (AP0 w/ linear encoding) to
+//          Arri LogC3 EI640
+//
+
+import "Lib.Academy.Utilities";
+import "Lib.Academy.ColorSpaces";
+
+const Chromaticities AP0 = // ACES Primaries from SMPTE ST2065-1
+    {
+        {0.73470, 0.26530},
+        {0.00000, 1.00000},
+        {0.00010, -0.07700},
+        {0.32168, 0.33767}};
+
+const Chromaticities ARRI_ALEXA_WG_PRI =
+    {
+        {0.68400, 0.31300},
+        {0.22100, 0.84800},
+        {0.08610, -0.10200},
+        {0.31270, 0.32900}};
+
+const float AP0_to_AWG3_MAT[3][3] = calculate_rgb_to_rgb_matrix(AP0,
+                                                                ARRI_ALEXA_WG_PRI,
+                                                                CONE_RESP_MAT_CAT02);
+
+const float nominalEI = 400.0;
+const float blackSignal = 16.0 / 4095.0;
+const float midGraySignal = 0.01;
+const float encodingGain = 500.0 / 1023.0 * 0.525;
+const float encodingOffset = 400.0 / 1023.0;
+const float cut = 1.0 / 9.0;
+const float slope = 1.0 / (cut * log(10.0));
+const float offset = log10(cut) - slope * cut;
+
+float relativeExposureToNormalizedSensor(float re, float EI)
+{
+    return re * (midGraySignal * nominalEI / EI) / 0.18 + blackSignal;
+}
+
+float relativeExposureToNormalizedLogC3(float re, float EI)
+{
+    float nz;
+    float out;
+    float ns;
+    const float gain = EI / nominalEI;
+    const float gray = midGraySignal / gain;
+    const float encGain = (log2(gain) * (0.89 - 1.0) / 3.0 + 1.0) * encodingGain;
+    float encOffset = encodingOffset;
+    for (int i = 0; i < 3; i = i + 1)
+    {
+        nz = ((95.0 / 1023.0 - encOffset) / encGain - offset) / slope;
+        encOffset = encodingOffset - log10(1.0 + nz) * encGain;
+    }
+    float xm = log10((1.0 - blackSignal) / gray + nz) * encGain + encOffset;
+
+    ns = relativeExposureToNormalizedSensor(re, EI);
+
+    ns = (ns - blackSignal) / gray + nz;
+
+    if (xm > 1) {
+        // Hermite blending region
+        // Tricky to implement an inverse unless needed. It might be possible to
+        // iteratively solve for a numerical inversion, but is currently not
+        // supported.
+        return 0;
+    } else { // Valid for EI values below 1600
+        if (ns > cut)
+        {
+            out = log10(ns);
+        } 
+        else
+        {
+            out = slope * ns + offset;
+        }
+    }
+
+    return out * encGain + encOffset;
+}
+
+void main(input varying float rIn,
+          input varying float gIn,
+          input varying float bIn,
+          input varying float aIn,
+          output varying float rOut,
+          output varying float gOut,
+          output varying float bOut,
+          output varying float aOut,
+          input uniform float EI = 640.0)
+{
+    float ACES[3] = {rIn, gIn, bIn};
+
+    float lin_AWG3[3] = mult_f3_f33(ACES, AP0_to_AWG3_MAT);
+
+    rOut = relativeExposureToNormalizedLogC3(lin_AWG3[0], EI);
+    gOut = relativeExposureToNormalizedLogC3(lin_AWG3[1], EI);
+    bOut = relativeExposureToNormalizedLogC3(lin_AWG3[2], EI);
+    aOut = aIn;
+}

--- a/arri/CSC.Arri.ACES_to_LogCv3-EI640.ctl
+++ b/arri/CSC.Arri.ACES_to_LogCv3-EI640.ctl
@@ -10,6 +10,7 @@
 
 import "Lib.Academy.Utilities";
 import "Lib.Academy.ColorSpaces";
+import "Lib.Arri.LogC3";
 
 const Chromaticities AP0 = // ACES Primaries from SMPTE ST2065-1
     {
@@ -29,59 +30,7 @@ const float AP0_to_AWG3_MAT[3][3] = calculate_rgb_to_rgb_matrix(AP0,
                                                                 ARRI_ALEXA_WG_PRI,
                                                                 CONE_RESP_MAT_CAT02);
 
-const float nominalEI = 400.0;
-const float blackSignal = 16.0 / 4095.0;
-const float midGraySignal = 0.01;
-const float encodingGain = 500.0 / 1023.0 * 0.525;
-const float encodingOffset = 400.0 / 1023.0;
-const float cut = 1.0 / 9.0;
-const float slope = 1.0 / (cut * log(10.0));
-const float offset = log10(cut) - slope * cut;
-
-float relativeExposureToNormalizedSensor(float re, float EI)
-{
-    return re * (midGraySignal * nominalEI / EI) / 0.18 + blackSignal;
-}
-
-float relativeExposureToNormalizedLogC3(float re, float EI)
-{
-    float nz;
-    float out;
-    float ns;
-    const float gain = EI / nominalEI;
-    const float gray = midGraySignal / gain;
-    const float encGain = (log2(gain) * (0.89 - 1.0) / 3.0 + 1.0) * encodingGain;
-    float encOffset = encodingOffset;
-    for (int i = 0; i < 3; i = i + 1)
-    {
-        nz = ((95.0 / 1023.0 - encOffset) / encGain - offset) / slope;
-        encOffset = encodingOffset - log10(1.0 + nz) * encGain;
-    }
-    float xm = log10((1.0 - blackSignal) / gray + nz) * encGain + encOffset;
-
-    ns = relativeExposureToNormalizedSensor(re, EI);
-
-    ns = (ns - blackSignal) / gray + nz;
-
-    if (xm > 1) {
-        // Hermite blending region
-        // Tricky to implement an inverse unless needed. It might be possible to
-        // iteratively solve for a numerical inversion, but is currently not
-        // supported.
-        return 0;
-    } else { // Valid for EI values below 1600
-        if (ns > cut)
-        {
-            out = log10(ns);
-        } 
-        else
-        {
-            out = slope * ns + offset;
-        }
-    }
-
-    return out * encGain + encOffset;
-}
+const float EI = 640.0;
 
 void main(input varying float rIn,
           input varying float gIn,
@@ -90,8 +39,7 @@ void main(input varying float rIn,
           output varying float rOut,
           output varying float gOut,
           output varying float bOut,
-          output varying float aOut,
-          input uniform float EI = 640.0)
+          output varying float aOut)
 {
     float ACES[3] = {rIn, gIn, bIn};
 

--- a/arri/CSC.Arri.ACES_to_LogCv3-EI640.ctl
+++ b/arri/CSC.Arri.ACES_to_LogCv3-EI640.ctl
@@ -9,26 +9,7 @@
 //
 
 import "Lib.Academy.Utilities";
-import "Lib.Academy.ColorSpaces";
 import "Lib.Arri.LogC3";
-
-const Chromaticities AP0 = // ACES Primaries from SMPTE ST2065-1
-    {
-        {0.73470, 0.26530},
-        {0.00000, 1.00000},
-        {0.00010, -0.07700},
-        {0.32168, 0.33767}};
-
-const Chromaticities ARRI_ALEXA_WG_PRI =
-    {
-        {0.68400, 0.31300},
-        {0.22100, 0.84800},
-        {0.08610, -0.10200},
-        {0.31270, 0.32900}};
-
-const float AP0_to_AWG3_MAT[3][3] = calculate_rgb_to_rgb_matrix(AP0,
-                                                                ARRI_ALEXA_WG_PRI,
-                                                                CONE_RESP_MAT_CAT02);
 
 const float EI = 640.0;
 

--- a/arri/CSC.Arri.ACES_to_LogCv3-EI800.ctl
+++ b/arri/CSC.Arri.ACES_to_LogCv3-EI800.ctl
@@ -10,6 +10,7 @@
 
 import "Lib.Academy.Utilities";
 import "Lib.Academy.ColorSpaces";
+import "Lib.Arri.LogC3";
 
 const Chromaticities AP0 = // ACES Primaries from SMPTE ST2065-1
     {
@@ -29,59 +30,7 @@ const float AP0_to_AWG3_MAT[3][3] = calculate_rgb_to_rgb_matrix(AP0,
                                                                 ARRI_ALEXA_WG_PRI,
                                                                 CONE_RESP_MAT_CAT02);
 
-const float nominalEI = 400.0;
-const float blackSignal = 16.0 / 4095.0;
-const float midGraySignal = 0.01;
-const float encodingGain = 500.0 / 1023.0 * 0.525;
-const float encodingOffset = 400.0 / 1023.0;
-const float cut = 1.0 / 9.0;
-const float slope = 1.0 / (cut * log(10.0));
-const float offset = log10(cut) - slope * cut;
-
-float relativeExposureToNormalizedSensor(float re, float EI)
-{
-    return re * (midGraySignal * nominalEI / EI) / 0.18 + blackSignal;
-}
-
-float relativeExposureToNormalizedLogC3(float re, float EI)
-{
-    float nz;
-    float out;
-    float ns;
-    const float gain = EI / nominalEI;
-    const float gray = midGraySignal / gain;
-    const float encGain = (log2(gain) * (0.89 - 1.0) / 3.0 + 1.0) * encodingGain;
-    float encOffset = encodingOffset;
-    for (int i = 0; i < 3; i = i + 1)
-    {
-        nz = ((95.0 / 1023.0 - encOffset) / encGain - offset) / slope;
-        encOffset = encodingOffset - log10(1.0 + nz) * encGain;
-    }
-    float xm = log10((1.0 - blackSignal) / gray + nz) * encGain + encOffset;
-
-    ns = relativeExposureToNormalizedSensor(re, EI);
-
-    ns = (ns - blackSignal) / gray + nz;
-
-    if (xm > 1) {
-        // Hermite blending region
-        // Tricky to implement an inverse unless needed. It might be possible to
-        // iteratively solve for a numerical inversion, but is currently not
-        // supported.
-        return 0;
-    } else { // Valid for EI values below 1600
-        if (ns > cut)
-        {
-            out = log10(ns);
-        } 
-        else
-        {
-            out = slope * ns + offset;
-        }
-    }
-
-    return out * encGain + encOffset;
-}
+const float EI = 800.0;
 
 void main(input varying float rIn,
           input varying float gIn,

--- a/arri/CSC.Arri.ACES_to_LogCv3-EI800.ctl
+++ b/arri/CSC.Arri.ACES_to_LogCv3-EI800.ctl
@@ -1,16 +1,11 @@
-// <ACEStransformID>urn:ampas:aces:transformId:v2.0:CSC.Arri.ACES_to_LogC3.a2.v1</ACEStransformID>
-// <ACESuserName>ACES2065-1 to ARRI LogC3</ACESuserName>
+// <ACEStransformID>urn:ampas:aces:transformId:v2.0:CSC.Arri.ACES_to_LogC3-EI800.a2.v1</ACEStransformID>
+// <ACESuserName>ACES2065-1 to ARRI LogC3 EI800</ACESuserName>
 
 //
-// ACES Color Space Conversion - ACES2065-1 to Arri LogC3
+// ACES Color Space Conversion - ACES2065-1 to Arri LogC3 EI800
 //
 // converts ACES2065-1 (AP0 w/ linear encoding) to
-//          Arri LogC3
-//
-//  NOTE: Like its LogC3-to-ACES counterpart, this ACES-to-LogC3 transform
-//  declares EI as a parameter, but defaults to 800. Due to the Hermite spline
-//  blending region between 0.8 and 1.0, the function currently will only work
-//  for EI values below 1600.
+//          Arri LogC3 EI800
 //
 
 import "Lib.Academy.Utilities";

--- a/arri/CSC.Arri.ACES_to_LogCv3-EI800.ctl
+++ b/arri/CSC.Arri.ACES_to_LogCv3-EI800.ctl
@@ -1,0 +1,109 @@
+// <ACEStransformID>urn:ampas:aces:transformId:v2.0:CSC.Arri.ACES_to_LogC3.a2.v1</ACEStransformID>
+// <ACESuserName>ACES2065-1 to ARRI LogC3</ACESuserName>
+
+//
+// ACES Color Space Conversion - ACES2065-1 to Arri LogC3
+//
+// converts ACES2065-1 (AP0 w/ linear encoding) to
+//          Arri LogC3
+//
+//  NOTE: Like its LogC3-to-ACES counterpart, this ACES-to-LogC3 transform
+//  declares EI as a parameter, but defaults to 800. Due to the Hermite spline
+//  blending region between 0.8 and 1.0, the function currently will only work
+//  for EI values below 1600.
+//
+
+import "Lib.Academy.Utilities";
+import "Lib.Academy.ColorSpaces";
+
+const Chromaticities AP0 = // ACES Primaries from SMPTE ST2065-1
+    {
+        {0.73470, 0.26530},
+        {0.00000, 1.00000},
+        {0.00010, -0.07700},
+        {0.32168, 0.33767}};
+
+const Chromaticities ARRI_ALEXA_WG_PRI =
+    {
+        {0.68400, 0.31300},
+        {0.22100, 0.84800},
+        {0.08610, -0.10200},
+        {0.31270, 0.32900}};
+
+const float AP0_to_AWG3_MAT[3][3] = calculate_rgb_to_rgb_matrix(AP0,
+                                                                ARRI_ALEXA_WG_PRI,
+                                                                CONE_RESP_MAT_CAT02);
+
+const float nominalEI = 400.0;
+const float blackSignal = 16.0 / 4095.0;
+const float midGraySignal = 0.01;
+const float encodingGain = 500.0 / 1023.0 * 0.525;
+const float encodingOffset = 400.0 / 1023.0;
+const float cut = 1.0 / 9.0;
+const float slope = 1.0 / (cut * log(10.0));
+const float offset = log10(cut) - slope * cut;
+
+float relativeExposureToNormalizedSensor(float re, float EI)
+{
+    return re * (midGraySignal * nominalEI / EI) / 0.18 + blackSignal;
+}
+
+float relativeExposureToNormalizedLogC3(float re, float EI)
+{
+    float nz;
+    float out;
+    float ns;
+    const float gain = EI / nominalEI;
+    const float gray = midGraySignal / gain;
+    const float encGain = (log2(gain) * (0.89 - 1.0) / 3.0 + 1.0) * encodingGain;
+    float encOffset = encodingOffset;
+    for (int i = 0; i < 3; i = i + 1)
+    {
+        nz = ((95.0 / 1023.0 - encOffset) / encGain - offset) / slope;
+        encOffset = encodingOffset - log10(1.0 + nz) * encGain;
+    }
+    float xm = log10((1.0 - blackSignal) / gray + nz) * encGain + encOffset;
+
+    ns = relativeExposureToNormalizedSensor(re, EI);
+
+    ns = (ns - blackSignal) / gray + nz;
+
+    if (xm > 1) {
+        // Hermite blending region
+        // Tricky to implement an inverse unless needed. It might be possible to
+        // iteratively solve for a numerical inversion, but is currently not
+        // supported.
+        return 0;
+    } else { // Valid for EI values below 1600
+        if (ns > cut)
+        {
+            out = log10(ns);
+        } 
+        else
+        {
+            out = slope * ns + offset;
+        }
+    }
+
+    return out * encGain + encOffset;
+}
+
+void main(input varying float rIn,
+          input varying float gIn,
+          input varying float bIn,
+          input varying float aIn,
+          output varying float rOut,
+          output varying float gOut,
+          output varying float bOut,
+          output varying float aOut,
+          input uniform float EI = 800.0)
+{
+    float ACES[3] = {rIn, gIn, bIn};
+
+    float lin_AWG3[3] = mult_f3_f33(ACES, AP0_to_AWG3_MAT);
+
+    rOut = relativeExposureToNormalizedLogC3(lin_AWG3[0], EI);
+    gOut = relativeExposureToNormalizedLogC3(lin_AWG3[1], EI);
+    bOut = relativeExposureToNormalizedLogC3(lin_AWG3[2], EI);
+    aOut = aIn;
+}

--- a/arri/CSC.Arri.ACES_to_LogCv3-EI800.ctl
+++ b/arri/CSC.Arri.ACES_to_LogCv3-EI800.ctl
@@ -39,8 +39,7 @@ void main(input varying float rIn,
           output varying float rOut,
           output varying float gOut,
           output varying float bOut,
-          output varying float aOut,
-          input uniform float EI = 800.0)
+          output varying float aOut)
 {
     float ACES[3] = {rIn, gIn, bIn};
 

--- a/arri/CSC.Arri.ACES_to_LogCv3-EI800.ctl
+++ b/arri/CSC.Arri.ACES_to_LogCv3-EI800.ctl
@@ -9,26 +9,7 @@
 //
 
 import "Lib.Academy.Utilities";
-import "Lib.Academy.ColorSpaces";
 import "Lib.Arri.LogC3";
-
-const Chromaticities AP0 = // ACES Primaries from SMPTE ST2065-1
-    {
-        {0.73470, 0.26530},
-        {0.00000, 1.00000},
-        {0.00010, -0.07700},
-        {0.32168, 0.33767}};
-
-const Chromaticities ARRI_ALEXA_WG_PRI =
-    {
-        {0.68400, 0.31300},
-        {0.22100, 0.84800},
-        {0.08610, -0.10200},
-        {0.31270, 0.32900}};
-
-const float AP0_to_AWG3_MAT[3][3] = calculate_rgb_to_rgb_matrix(AP0,
-                                                                ARRI_ALEXA_WG_PRI,
-                                                                CONE_RESP_MAT_CAT02);
 
 const float EI = 800.0;
 

--- a/arri/CSC.Arri.ACES_to_LogCv3.ctl
+++ b/arri/CSC.Arri.ACES_to_LogCv3.ctl
@@ -15,6 +15,7 @@
 
 import "Lib.Academy.Utilities";
 import "Lib.Academy.ColorSpaces";
+import "Lib.Arri.LogC3";
 
 const Chromaticities AP0 = // ACES Primaries from SMPTE ST2065-1
     {
@@ -33,60 +34,6 @@ const Chromaticities ARRI_ALEXA_WG_PRI =
 const float AP0_to_AWG3_MAT[3][3] = calculate_rgb_to_rgb_matrix(AP0,
                                                                 ARRI_ALEXA_WG_PRI,
                                                                 CONE_RESP_MAT_CAT02);
-
-const float nominalEI = 400.0;
-const float blackSignal = 16.0 / 4095.0;
-const float midGraySignal = 0.01;
-const float encodingGain = 500.0 / 1023.0 * 0.525;
-const float encodingOffset = 400.0 / 1023.0;
-const float cut = 1.0 / 9.0;
-const float slope = 1.0 / (cut * log(10.0));
-const float offset = log10(cut) - slope * cut;
-
-float relativeExposureToNormalizedSensor(float re, float EI)
-{
-    return re * (midGraySignal * nominalEI / EI) / 0.18 + blackSignal;
-}
-
-float relativeExposureToNormalizedLogC3(float re, float EI)
-{
-    float nz;
-    float out;
-    float ns;
-    const float gain = EI / nominalEI;
-    const float gray = midGraySignal / gain;
-    const float encGain = (log2(gain) * (0.89 - 1.0) / 3.0 + 1.0) * encodingGain;
-    float encOffset = encodingOffset;
-    for (int i = 0; i < 3; i = i + 1)
-    {
-        nz = ((95.0 / 1023.0 - encOffset) / encGain - offset) / slope;
-        encOffset = encodingOffset - log10(1.0 + nz) * encGain;
-    }
-    float xm = log10((1.0 - blackSignal) / gray + nz) * encGain + encOffset;
-
-    ns = relativeExposureToNormalizedSensor(re, EI);
-
-    ns = (ns - blackSignal) / gray + nz;
-
-    if (xm > 1) {
-        // Hermite blending region
-        // Tricky to implement an inverse unless needed. It might be possible to
-        // iteratively solve for a numerical inversion, but is currently not
-        // supported.
-        return 0;
-    } else { // Valid for EI values below 1600
-        if (ns > cut)
-        {
-            out = log10(ns);
-        } 
-        else
-        {
-            out = slope * ns + offset;
-        }
-    }
-
-    return out * encGain + encOffset;
-}
 
 void main(input varying float rIn,
           input varying float gIn,

--- a/arri/CSC.Arri.ACES_to_LogCv3.ctl
+++ b/arri/CSC.Arri.ACES_to_LogCv3.ctl
@@ -14,26 +14,7 @@
 //
 
 import "Lib.Academy.Utilities";
-import "Lib.Academy.ColorSpaces";
 import "Lib.Arri.LogC3";
-
-const Chromaticities AP0 = // ACES Primaries from SMPTE ST2065-1
-    {
-        {0.73470, 0.26530},
-        {0.00000, 1.00000},
-        {0.00010, -0.07700},
-        {0.32168, 0.33767}};
-
-const Chromaticities ARRI_ALEXA_WG_PRI =
-    {
-        {0.68400, 0.31300},
-        {0.22100, 0.84800},
-        {0.08610, -0.10200},
-        {0.31270, 0.32900}};
-
-const float AP0_to_AWG3_MAT[3][3] = calculate_rgb_to_rgb_matrix(AP0,
-                                                                ARRI_ALEXA_WG_PRI,
-                                                                CONE_RESP_MAT_CAT02);
 
 void main(input varying float rIn,
           input varying float gIn,

--- a/arri/CSC.Arri.LogCv3-EI1000_to_ACES.ctl
+++ b/arri/CSC.Arri.LogCv3-EI1000_to_ACES.ctl
@@ -13,6 +13,7 @@
 
 import "Lib.Academy.Utilities";
 import "Lib.Academy.ColorSpaces";
+import "Lib.Arri.LogC3";
 
 const Chromaticities AP0 = // ACES Primaries from SMPTE ST2065-1
     {
@@ -32,79 +33,7 @@ const float AWG3_to_AP0_MAT[3][3] = calculate_rgb_to_rgb_matrix(ARRI_ALEXA_WG_PR
                                                                 AP0,
                                                                 CONE_RESP_MAT_CAT02);
 
-const float nominalEI = 400.0;
-const float blackSignal = 16.0 / 4095.0;
-const float midGraySignal = 0.01;
-const float encodingGain = 500.0 / 1023.0 * 0.525;
-const float encodingOffset = 400.0 / 1023.0;
-const float cut = 1.0 / 9.0;
-const float slope = 1.0 / (cut * log(10.0));
-const float offset = log10(cut) - slope * cut;
-
-float[4] hermiteWeights(float x, float x1, float x2)
-{
-    const float d = x2 - x1;
-    const float s = (x - x1) / d;
-    const float s2 = 1.0 - s;
-    float out[4];
-    out[0] = (1.0 + 2.0 * s) * s2 * s2;
-    out[1] = (3.0 - 2.0 * s) * s * s;
-    out[2] = d * s * s2 * s2;
-    out[3] = -d * s * s * s2;
-    return out;
-}
-
-float normalizedSensorToRelativeExposure(float ns, float EI)
-{
-    return (ns - blackSignal) * (0.18 / (midGraySignal * nominalEI / EI));
-}
-
-float normalizedLogC3ToRelativeExposure(float t, float EI)
-{
-    float nz;
-    float out;
-    float ns;
-    const float gain = EI / nominalEI;
-    const float gray = midGraySignal / gain;
-    const float encGain = (log2(gain) * (0.89 - 1.0) / 3.0 + 1.0) * encodingGain;
-    float encOffset = encodingOffset;
-    for (int i = 0; i < 3; i = i + 1)
-    {
-        nz = ((95.0 / 1023.0 - encOffset) / encGain - offset) / slope;
-        encOffset = encodingOffset - log10(1.0 + nz) * encGain;
-    }
-    float xm = log10((1.0 - blackSignal) / gray + nz) * encGain + encOffset;
-    if (xm > 1)
-    {
-        float hw[4] = hermiteWeights(t, 0.8, 1.0);
-        float d = 0.2 / (xm - 0.8);
-        float v[4];
-        v[0] = 0.8;
-        v[1] = xm;
-        v[2] = 1.0;
-        v[3] = 1.0 / (d * d);
-        if (t <= 0.8)
-        {
-            out = t;
-        }
-        else
-        {
-            out = hw[0] * v[0] + hw[1] * v[1] + hw[2] * v[2] + hw[3] * v[3];
-        }
-    }
-    else
-    {
-        out = t;
-    }
-    out = (out - encOffset) / encGain;
-    ns = (out - offset) / slope;
-    if (ns > cut)
-    {
-        ns = pow(10.0, out);
-    }
-    ns = (ns - nz) * gray + blackSignal;
-    return normalizedSensorToRelativeExposure(ns, EI);
-}
+const float EI = 1000.0;
 
 void main(input varying float rIn,
           input varying float gIn,
@@ -113,8 +42,7 @@ void main(input varying float rIn,
           output varying float rOut,
           output varying float gOut,
           output varying float bOut,
-          output varying float aOut,
-          input uniform float EI = 1000.0)
+          output varying float aOut)
 {
     float lin_AWG3[3];
     lin_AWG3[0] = normalizedLogC3ToRelativeExposure(rIn, EI);

--- a/arri/CSC.Arri.LogCv3-EI1000_to_ACES.ctl
+++ b/arri/CSC.Arri.LogCv3-EI1000_to_ACES.ctl
@@ -1,16 +1,14 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Contributors to the ACES Project.
 
-// <ACEStransformID>urn:ampas:aces:transformId:v2.0:CSC.Arri.LogC3_to_ACES.a2.v1</ACEStransformID>
-// <ACESuserName>ARRI LogC3 to ACES2065-1</ACESuserName>
+// <ACEStransformID>urn:ampas:aces:transformId:v2.0:CSC.Arri.LogC3-EI1000_to_ACES.a2.v1</ACEStransformID>
+// <ACESuserName>ARRI LogC3 EI1000 to ACES2065-1</ACESuserName>
 
 //
-// ACES Color Space Conversion - Arri LogC3 to ACES2065-1
+// ACES Color Space Conversion - Arri LogC3 EI1000 to ACES2065-1
 //
-// converts Arri LogC3 to
+// converts Arri LogC3 EI1000 to
 //          ACES2065-1 (AP0 w/ linear encoding)
-//
-// NOTE: In this transform EI is a parameter, defaulted to EI800.
 //
 
 import "Lib.Academy.Utilities";
@@ -116,7 +114,7 @@ void main(input varying float rIn,
           output varying float gOut,
           output varying float bOut,
           output varying float aOut,
-          input uniform float EI = 800.0)
+          input uniform float EI = 1000.0)
 {
     float lin_AWG3[3];
     lin_AWG3[0] = normalizedLogC3ToRelativeExposure(rIn, EI);

--- a/arri/CSC.Arri.LogCv3-EI1000_to_ACES.ctl
+++ b/arri/CSC.Arri.LogCv3-EI1000_to_ACES.ctl
@@ -12,26 +12,7 @@
 //
 
 import "Lib.Academy.Utilities";
-import "Lib.Academy.ColorSpaces";
 import "Lib.Arri.LogC3";
-
-const Chromaticities AP0 = // ACES Primaries from SMPTE ST2065-1
-    {
-        {0.73470, 0.26530},
-        {0.00000, 1.00000},
-        {0.00010, -0.07700},
-        {0.32168, 0.33767}};
-
-const Chromaticities ARRI_ALEXA_WG_PRI =
-    {
-        {0.68400, 0.31300},
-        {0.22100, 0.84800},
-        {0.08610, -0.10200},
-        {0.31270, 0.32900}};
-
-const float AWG3_to_AP0_MAT[3][3] = calculate_rgb_to_rgb_matrix(ARRI_ALEXA_WG_PRI,
-                                                                AP0,
-                                                                CONE_RESP_MAT_CAT02);
 
 const float EI = 1000.0;
 

--- a/arri/CSC.Arri.LogCv3-EI1280_to_ACES.ctl
+++ b/arri/CSC.Arri.LogCv3-EI1280_to_ACES.ctl
@@ -1,16 +1,14 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Contributors to the ACES Project.
 
-// <ACEStransformID>urn:ampas:aces:transformId:v2.0:CSC.Arri.LogC3_to_ACES.a2.v1</ACEStransformID>
-// <ACESuserName>ARRI LogC3 to ACES2065-1</ACESuserName>
+// <ACEStransformID>urn:ampas:aces:transformId:v2.0:CSC.Arri.LogC3-EI1280_to_ACES.a2.v1</ACEStransformID>
+// <ACESuserName>ARRI LogC3 EI1280 to ACES2065-1</ACESuserName>
 
 //
-// ACES Color Space Conversion - Arri LogC3 to ACES2065-1
+// ACES Color Space Conversion - Arri LogC3 EI1280 to ACES2065-1
 //
-// converts Arri LogC3 to
+// converts Arri LogC3 EI1280 to
 //          ACES2065-1 (AP0 w/ linear encoding)
-//
-// NOTE: In this transform EI is a parameter, defaulted to EI800.
 //
 
 import "Lib.Academy.Utilities";
@@ -116,7 +114,7 @@ void main(input varying float rIn,
           output varying float gOut,
           output varying float bOut,
           output varying float aOut,
-          input uniform float EI = 800.0)
+          input uniform float EI = 1280.0)
 {
     float lin_AWG3[3];
     lin_AWG3[0] = normalizedLogC3ToRelativeExposure(rIn, EI);

--- a/arri/CSC.Arri.LogCv3-EI1280_to_ACES.ctl
+++ b/arri/CSC.Arri.LogCv3-EI1280_to_ACES.ctl
@@ -13,6 +13,7 @@
 
 import "Lib.Academy.Utilities";
 import "Lib.Academy.ColorSpaces";
+import "Lib.Arri.LogC3";
 
 const Chromaticities AP0 = // ACES Primaries from SMPTE ST2065-1
     {
@@ -32,79 +33,7 @@ const float AWG3_to_AP0_MAT[3][3] = calculate_rgb_to_rgb_matrix(ARRI_ALEXA_WG_PR
                                                                 AP0,
                                                                 CONE_RESP_MAT_CAT02);
 
-const float nominalEI = 400.0;
-const float blackSignal = 16.0 / 4095.0;
-const float midGraySignal = 0.01;
-const float encodingGain = 500.0 / 1023.0 * 0.525;
-const float encodingOffset = 400.0 / 1023.0;
-const float cut = 1.0 / 9.0;
-const float slope = 1.0 / (cut * log(10.0));
-const float offset = log10(cut) - slope * cut;
-
-float[4] hermiteWeights(float x, float x1, float x2)
-{
-    const float d = x2 - x1;
-    const float s = (x - x1) / d;
-    const float s2 = 1.0 - s;
-    float out[4];
-    out[0] = (1.0 + 2.0 * s) * s2 * s2;
-    out[1] = (3.0 - 2.0 * s) * s * s;
-    out[2] = d * s * s2 * s2;
-    out[3] = -d * s * s * s2;
-    return out;
-}
-
-float normalizedSensorToRelativeExposure(float ns, float EI)
-{
-    return (ns - blackSignal) * (0.18 / (midGraySignal * nominalEI / EI));
-}
-
-float normalizedLogC3ToRelativeExposure(float t, float EI)
-{
-    float nz;
-    float out;
-    float ns;
-    const float gain = EI / nominalEI;
-    const float gray = midGraySignal / gain;
-    const float encGain = (log2(gain) * (0.89 - 1.0) / 3.0 + 1.0) * encodingGain;
-    float encOffset = encodingOffset;
-    for (int i = 0; i < 3; i = i + 1)
-    {
-        nz = ((95.0 / 1023.0 - encOffset) / encGain - offset) / slope;
-        encOffset = encodingOffset - log10(1.0 + nz) * encGain;
-    }
-    float xm = log10((1.0 - blackSignal) / gray + nz) * encGain + encOffset;
-    if (xm > 1)
-    {
-        float hw[4] = hermiteWeights(t, 0.8, 1.0);
-        float d = 0.2 / (xm - 0.8);
-        float v[4];
-        v[0] = 0.8;
-        v[1] = xm;
-        v[2] = 1.0;
-        v[3] = 1.0 / (d * d);
-        if (t <= 0.8)
-        {
-            out = t;
-        }
-        else
-        {
-            out = hw[0] * v[0] + hw[1] * v[1] + hw[2] * v[2] + hw[3] * v[3];
-        }
-    }
-    else
-    {
-        out = t;
-    }
-    out = (out - encOffset) / encGain;
-    ns = (out - offset) / slope;
-    if (ns > cut)
-    {
-        ns = pow(10.0, out);
-    }
-    ns = (ns - nz) * gray + blackSignal;
-    return normalizedSensorToRelativeExposure(ns, EI);
-}
+const float EI = 1280.0;
 
 void main(input varying float rIn,
           input varying float gIn,
@@ -113,8 +42,7 @@ void main(input varying float rIn,
           output varying float rOut,
           output varying float gOut,
           output varying float bOut,
-          output varying float aOut,
-          input uniform float EI = 1280.0)
+          output varying float aOut)
 {
     float lin_AWG3[3];
     lin_AWG3[0] = normalizedLogC3ToRelativeExposure(rIn, EI);

--- a/arri/CSC.Arri.LogCv3-EI1280_to_ACES.ctl
+++ b/arri/CSC.Arri.LogCv3-EI1280_to_ACES.ctl
@@ -12,26 +12,7 @@
 //
 
 import "Lib.Academy.Utilities";
-import "Lib.Academy.ColorSpaces";
 import "Lib.Arri.LogC3";
-
-const Chromaticities AP0 = // ACES Primaries from SMPTE ST2065-1
-    {
-        {0.73470, 0.26530},
-        {0.00000, 1.00000},
-        {0.00010, -0.07700},
-        {0.32168, 0.33767}};
-
-const Chromaticities ARRI_ALEXA_WG_PRI =
-    {
-        {0.68400, 0.31300},
-        {0.22100, 0.84800},
-        {0.08610, -0.10200},
-        {0.31270, 0.32900}};
-
-const float AWG3_to_AP0_MAT[3][3] = calculate_rgb_to_rgb_matrix(ARRI_ALEXA_WG_PRI,
-                                                                AP0,
-                                                                CONE_RESP_MAT_CAT02);
 
 const float EI = 1280.0;
 

--- a/arri/CSC.Arri.LogCv3-EI1600_to_ACES.ctl
+++ b/arri/CSC.Arri.LogCv3-EI1600_to_ACES.ctl
@@ -1,16 +1,14 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Contributors to the ACES Project.
 
-// <ACEStransformID>urn:ampas:aces:transformId:v2.0:CSC.Arri.LogC3_to_ACES.a2.v1</ACEStransformID>
-// <ACESuserName>ARRI LogC3 to ACES2065-1</ACESuserName>
+// <ACEStransformID>urn:ampas:aces:transformId:v2.0:CSC.Arri.LogC3-EI1600_to_ACES.a2.v1</ACEStransformID>
+// <ACESuserName>ARRI LogC3 EI1600 to ACES2065-1</ACESuserName>
 
 //
-// ACES Color Space Conversion - Arri LogC3 to ACES2065-1
+// ACES Color Space Conversion - Arri LogC3 EI1600 to ACES2065-1
 //
-// converts Arri LogC3 to
+// converts Arri LogC3 EI1600 to
 //          ACES2065-1 (AP0 w/ linear encoding)
-//
-// NOTE: In this transform EI is a parameter, defaulted to EI800.
 //
 
 import "Lib.Academy.Utilities";
@@ -116,7 +114,7 @@ void main(input varying float rIn,
           output varying float gOut,
           output varying float bOut,
           output varying float aOut,
-          input uniform float EI = 800.0)
+          input uniform float EI = 1600.0)
 {
     float lin_AWG3[3];
     lin_AWG3[0] = normalizedLogC3ToRelativeExposure(rIn, EI);

--- a/arri/CSC.Arri.LogCv3-EI1600_to_ACES.ctl
+++ b/arri/CSC.Arri.LogCv3-EI1600_to_ACES.ctl
@@ -13,6 +13,7 @@
 
 import "Lib.Academy.Utilities";
 import "Lib.Academy.ColorSpaces";
+import "Lib.Arri.LogC3";
 
 const Chromaticities AP0 = // ACES Primaries from SMPTE ST2065-1
     {
@@ -32,79 +33,7 @@ const float AWG3_to_AP0_MAT[3][3] = calculate_rgb_to_rgb_matrix(ARRI_ALEXA_WG_PR
                                                                 AP0,
                                                                 CONE_RESP_MAT_CAT02);
 
-const float nominalEI = 400.0;
-const float blackSignal = 16.0 / 4095.0;
-const float midGraySignal = 0.01;
-const float encodingGain = 500.0 / 1023.0 * 0.525;
-const float encodingOffset = 400.0 / 1023.0;
-const float cut = 1.0 / 9.0;
-const float slope = 1.0 / (cut * log(10.0));
-const float offset = log10(cut) - slope * cut;
-
-float[4] hermiteWeights(float x, float x1, float x2)
-{
-    const float d = x2 - x1;
-    const float s = (x - x1) / d;
-    const float s2 = 1.0 - s;
-    float out[4];
-    out[0] = (1.0 + 2.0 * s) * s2 * s2;
-    out[1] = (3.0 - 2.0 * s) * s * s;
-    out[2] = d * s * s2 * s2;
-    out[3] = -d * s * s * s2;
-    return out;
-}
-
-float normalizedSensorToRelativeExposure(float ns, float EI)
-{
-    return (ns - blackSignal) * (0.18 / (midGraySignal * nominalEI / EI));
-}
-
-float normalizedLogC3ToRelativeExposure(float t, float EI)
-{
-    float nz;
-    float out;
-    float ns;
-    const float gain = EI / nominalEI;
-    const float gray = midGraySignal / gain;
-    const float encGain = (log2(gain) * (0.89 - 1.0) / 3.0 + 1.0) * encodingGain;
-    float encOffset = encodingOffset;
-    for (int i = 0; i < 3; i = i + 1)
-    {
-        nz = ((95.0 / 1023.0 - encOffset) / encGain - offset) / slope;
-        encOffset = encodingOffset - log10(1.0 + nz) * encGain;
-    }
-    float xm = log10((1.0 - blackSignal) / gray + nz) * encGain + encOffset;
-    if (xm > 1)
-    {
-        float hw[4] = hermiteWeights(t, 0.8, 1.0);
-        float d = 0.2 / (xm - 0.8);
-        float v[4];
-        v[0] = 0.8;
-        v[1] = xm;
-        v[2] = 1.0;
-        v[3] = 1.0 / (d * d);
-        if (t <= 0.8)
-        {
-            out = t;
-        }
-        else
-        {
-            out = hw[0] * v[0] + hw[1] * v[1] + hw[2] * v[2] + hw[3] * v[3];
-        }
-    }
-    else
-    {
-        out = t;
-    }
-    out = (out - encOffset) / encGain;
-    ns = (out - offset) / slope;
-    if (ns > cut)
-    {
-        ns = pow(10.0, out);
-    }
-    ns = (ns - nz) * gray + blackSignal;
-    return normalizedSensorToRelativeExposure(ns, EI);
-}
+const float EI = 1600.0;
 
 void main(input varying float rIn,
           input varying float gIn,
@@ -113,8 +42,7 @@ void main(input varying float rIn,
           output varying float rOut,
           output varying float gOut,
           output varying float bOut,
-          output varying float aOut,
-          input uniform float EI = 1600.0)
+          output varying float aOut)
 {
     float lin_AWG3[3];
     lin_AWG3[0] = normalizedLogC3ToRelativeExposure(rIn, EI);

--- a/arri/CSC.Arri.LogCv3-EI1600_to_ACES.ctl
+++ b/arri/CSC.Arri.LogCv3-EI1600_to_ACES.ctl
@@ -12,26 +12,7 @@
 //
 
 import "Lib.Academy.Utilities";
-import "Lib.Academy.ColorSpaces";
 import "Lib.Arri.LogC3";
-
-const Chromaticities AP0 = // ACES Primaries from SMPTE ST2065-1
-    {
-        {0.73470, 0.26530},
-        {0.00000, 1.00000},
-        {0.00010, -0.07700},
-        {0.32168, 0.33767}};
-
-const Chromaticities ARRI_ALEXA_WG_PRI =
-    {
-        {0.68400, 0.31300},
-        {0.22100, 0.84800},
-        {0.08610, -0.10200},
-        {0.31270, 0.32900}};
-
-const float AWG3_to_AP0_MAT[3][3] = calculate_rgb_to_rgb_matrix(ARRI_ALEXA_WG_PRI,
-                                                                AP0,
-                                                                CONE_RESP_MAT_CAT02);
 
 const float EI = 1600.0;
 

--- a/arri/CSC.Arri.LogCv3-EI160_to_ACES.ctl
+++ b/arri/CSC.Arri.LogCv3-EI160_to_ACES.ctl
@@ -13,6 +13,7 @@
 
 import "Lib.Academy.Utilities";
 import "Lib.Academy.ColorSpaces";
+import "Lib.Arri.LogC3";
 
 const Chromaticities AP0 = // ACES Primaries from SMPTE ST2065-1
     {
@@ -32,79 +33,7 @@ const float AWG3_to_AP0_MAT[3][3] = calculate_rgb_to_rgb_matrix(ARRI_ALEXA_WG_PR
                                                                 AP0,
                                                                 CONE_RESP_MAT_CAT02);
 
-const float nominalEI = 400.0;
-const float blackSignal = 16.0 / 4095.0;
-const float midGraySignal = 0.01;
-const float encodingGain = 500.0 / 1023.0 * 0.525;
-const float encodingOffset = 400.0 / 1023.0;
-const float cut = 1.0 / 9.0;
-const float slope = 1.0 / (cut * log(10.0));
-const float offset = log10(cut) - slope * cut;
-
-float[4] hermiteWeights(float x, float x1, float x2)
-{
-    const float d = x2 - x1;
-    const float s = (x - x1) / d;
-    const float s2 = 1.0 - s;
-    float out[4];
-    out[0] = (1.0 + 2.0 * s) * s2 * s2;
-    out[1] = (3.0 - 2.0 * s) * s * s;
-    out[2] = d * s * s2 * s2;
-    out[3] = -d * s * s * s2;
-    return out;
-}
-
-float normalizedSensorToRelativeExposure(float ns, float EI)
-{
-    return (ns - blackSignal) * (0.18 / (midGraySignal * nominalEI / EI));
-}
-
-float normalizedLogC3ToRelativeExposure(float t, float EI)
-{
-    float nz;
-    float out;
-    float ns;
-    const float gain = EI / nominalEI;
-    const float gray = midGraySignal / gain;
-    const float encGain = (log2(gain) * (0.89 - 1.0) / 3.0 + 1.0) * encodingGain;
-    float encOffset = encodingOffset;
-    for (int i = 0; i < 3; i = i + 1)
-    {
-        nz = ((95.0 / 1023.0 - encOffset) / encGain - offset) / slope;
-        encOffset = encodingOffset - log10(1.0 + nz) * encGain;
-    }
-    float xm = log10((1.0 - blackSignal) / gray + nz) * encGain + encOffset;
-    if (xm > 1)
-    {
-        float hw[4] = hermiteWeights(t, 0.8, 1.0);
-        float d = 0.2 / (xm - 0.8);
-        float v[4];
-        v[0] = 0.8;
-        v[1] = xm;
-        v[2] = 1.0;
-        v[3] = 1.0 / (d * d);
-        if (t <= 0.8)
-        {
-            out = t;
-        }
-        else
-        {
-            out = hw[0] * v[0] + hw[1] * v[1] + hw[2] * v[2] + hw[3] * v[3];
-        }
-    }
-    else
-    {
-        out = t;
-    }
-    out = (out - encOffset) / encGain;
-    ns = (out - offset) / slope;
-    if (ns > cut)
-    {
-        ns = pow(10.0, out);
-    }
-    ns = (ns - nz) * gray + blackSignal;
-    return normalizedSensorToRelativeExposure(ns, EI);
-}
+const float EI = 160.0;
 
 void main(input varying float rIn,
           input varying float gIn,
@@ -113,8 +42,7 @@ void main(input varying float rIn,
           output varying float rOut,
           output varying float gOut,
           output varying float bOut,
-          output varying float aOut,
-          input uniform float EI = 160.0)
+          output varying float aOut)
 {
     float lin_AWG3[3];
     lin_AWG3[0] = normalizedLogC3ToRelativeExposure(rIn, EI);

--- a/arri/CSC.Arri.LogCv3-EI160_to_ACES.ctl
+++ b/arri/CSC.Arri.LogCv3-EI160_to_ACES.ctl
@@ -1,16 +1,14 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Contributors to the ACES Project.
 
-// <ACEStransformID>urn:ampas:aces:transformId:v2.0:CSC.Arri.LogC3_to_ACES.a2.v1</ACEStransformID>
-// <ACESuserName>ARRI LogC3 to ACES2065-1</ACESuserName>
+// <ACEStransformID>urn:ampas:aces:transformId:v2.0:CSC.Arri.LogC3-EI160_to_ACES.a2.v1</ACEStransformID>
+// <ACESuserName>ARRI LogC3 EI160 to ACES2065-1</ACESuserName>
 
 //
-// ACES Color Space Conversion - Arri LogC3 to ACES2065-1
+// ACES Color Space Conversion - Arri LogC3 EI160 to ACES2065-1
 //
-// converts Arri LogC3 to
+// converts Arri LogC3 EI160 to
 //          ACES2065-1 (AP0 w/ linear encoding)
-//
-// NOTE: In this transform EI is a parameter, defaulted to EI800.
 //
 
 import "Lib.Academy.Utilities";
@@ -116,7 +114,7 @@ void main(input varying float rIn,
           output varying float gOut,
           output varying float bOut,
           output varying float aOut,
-          input uniform float EI = 800.0)
+          input uniform float EI = 160.0)
 {
     float lin_AWG3[3];
     lin_AWG3[0] = normalizedLogC3ToRelativeExposure(rIn, EI);

--- a/arri/CSC.Arri.LogCv3-EI160_to_ACES.ctl
+++ b/arri/CSC.Arri.LogCv3-EI160_to_ACES.ctl
@@ -12,26 +12,7 @@
 //
 
 import "Lib.Academy.Utilities";
-import "Lib.Academy.ColorSpaces";
 import "Lib.Arri.LogC3";
-
-const Chromaticities AP0 = // ACES Primaries from SMPTE ST2065-1
-    {
-        {0.73470, 0.26530},
-        {0.00000, 1.00000},
-        {0.00010, -0.07700},
-        {0.32168, 0.33767}};
-
-const Chromaticities ARRI_ALEXA_WG_PRI =
-    {
-        {0.68400, 0.31300},
-        {0.22100, 0.84800},
-        {0.08610, -0.10200},
-        {0.31270, 0.32900}};
-
-const float AWG3_to_AP0_MAT[3][3] = calculate_rgb_to_rgb_matrix(ARRI_ALEXA_WG_PRI,
-                                                                AP0,
-                                                                CONE_RESP_MAT_CAT02);
 
 const float EI = 160.0;
 

--- a/arri/CSC.Arri.LogCv3-EI2000_to_ACES.ctl
+++ b/arri/CSC.Arri.LogCv3-EI2000_to_ACES.ctl
@@ -13,6 +13,7 @@
 
 import "Lib.Academy.Utilities";
 import "Lib.Academy.ColorSpaces";
+import "Lib.Arri.LogC3";
 
 const Chromaticities AP0 = // ACES Primaries from SMPTE ST2065-1
     {
@@ -32,79 +33,7 @@ const float AWG3_to_AP0_MAT[3][3] = calculate_rgb_to_rgb_matrix(ARRI_ALEXA_WG_PR
                                                                 AP0,
                                                                 CONE_RESP_MAT_CAT02);
 
-const float nominalEI = 400.0;
-const float blackSignal = 16.0 / 4095.0;
-const float midGraySignal = 0.01;
-const float encodingGain = 500.0 / 1023.0 * 0.525;
-const float encodingOffset = 400.0 / 1023.0;
-const float cut = 1.0 / 9.0;
-const float slope = 1.0 / (cut * log(10.0));
-const float offset = log10(cut) - slope * cut;
-
-float[4] hermiteWeights(float x, float x1, float x2)
-{
-    const float d = x2 - x1;
-    const float s = (x - x1) / d;
-    const float s2 = 1.0 - s;
-    float out[4];
-    out[0] = (1.0 + 2.0 * s) * s2 * s2;
-    out[1] = (3.0 - 2.0 * s) * s * s;
-    out[2] = d * s * s2 * s2;
-    out[3] = -d * s * s * s2;
-    return out;
-}
-
-float normalizedSensorToRelativeExposure(float ns, float EI)
-{
-    return (ns - blackSignal) * (0.18 / (midGraySignal * nominalEI / EI));
-}
-
-float normalizedLogC3ToRelativeExposure(float t, float EI)
-{
-    float nz;
-    float out;
-    float ns;
-    const float gain = EI / nominalEI;
-    const float gray = midGraySignal / gain;
-    const float encGain = (log2(gain) * (0.89 - 1.0) / 3.0 + 1.0) * encodingGain;
-    float encOffset = encodingOffset;
-    for (int i = 0; i < 3; i = i + 1)
-    {
-        nz = ((95.0 / 1023.0 - encOffset) / encGain - offset) / slope;
-        encOffset = encodingOffset - log10(1.0 + nz) * encGain;
-    }
-    float xm = log10((1.0 - blackSignal) / gray + nz) * encGain + encOffset;
-    if (xm > 1)
-    {
-        float hw[4] = hermiteWeights(t, 0.8, 1.0);
-        float d = 0.2 / (xm - 0.8);
-        float v[4];
-        v[0] = 0.8;
-        v[1] = xm;
-        v[2] = 1.0;
-        v[3] = 1.0 / (d * d);
-        if (t <= 0.8)
-        {
-            out = t;
-        }
-        else
-        {
-            out = hw[0] * v[0] + hw[1] * v[1] + hw[2] * v[2] + hw[3] * v[3];
-        }
-    }
-    else
-    {
-        out = t;
-    }
-    out = (out - encOffset) / encGain;
-    ns = (out - offset) / slope;
-    if (ns > cut)
-    {
-        ns = pow(10.0, out);
-    }
-    ns = (ns - nz) * gray + blackSignal;
-    return normalizedSensorToRelativeExposure(ns, EI);
-}
+const float EI = 2000.0;
 
 void main(input varying float rIn,
           input varying float gIn,
@@ -113,8 +42,7 @@ void main(input varying float rIn,
           output varying float rOut,
           output varying float gOut,
           output varying float bOut,
-          output varying float aOut,
-          input uniform float EI = 2000.0)
+          output varying float aOut)
 {
     float lin_AWG3[3];
     lin_AWG3[0] = normalizedLogC3ToRelativeExposure(rIn, EI);

--- a/arri/CSC.Arri.LogCv3-EI2000_to_ACES.ctl
+++ b/arri/CSC.Arri.LogCv3-EI2000_to_ACES.ctl
@@ -1,16 +1,14 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Contributors to the ACES Project.
 
-// <ACEStransformID>urn:ampas:aces:transformId:v2.0:CSC.Arri.LogC3_to_ACES.a2.v1</ACEStransformID>
-// <ACESuserName>ARRI LogC3 to ACES2065-1</ACESuserName>
+// <ACEStransformID>urn:ampas:aces:transformId:v2.0:CSC.Arri.LogC3-EI2000_to_ACES.a2.v1</ACEStransformID>
+// <ACESuserName>ARRI LogC3 EI2000 to ACES2065-1</ACESuserName>
 
 //
-// ACES Color Space Conversion - Arri LogC3 to ACES2065-1
+// ACES Color Space Conversion - Arri LogC3 EI2000 to ACES2065-1
 //
-// converts Arri LogC3 to
+// converts Arri LogC3 EI2000 to
 //          ACES2065-1 (AP0 w/ linear encoding)
-//
-// NOTE: In this transform EI is a parameter, defaulted to EI800.
 //
 
 import "Lib.Academy.Utilities";
@@ -116,7 +114,7 @@ void main(input varying float rIn,
           output varying float gOut,
           output varying float bOut,
           output varying float aOut,
-          input uniform float EI = 800.0)
+          input uniform float EI = 2000.0)
 {
     float lin_AWG3[3];
     lin_AWG3[0] = normalizedLogC3ToRelativeExposure(rIn, EI);

--- a/arri/CSC.Arri.LogCv3-EI2000_to_ACES.ctl
+++ b/arri/CSC.Arri.LogCv3-EI2000_to_ACES.ctl
@@ -12,26 +12,7 @@
 //
 
 import "Lib.Academy.Utilities";
-import "Lib.Academy.ColorSpaces";
 import "Lib.Arri.LogC3";
-
-const Chromaticities AP0 = // ACES Primaries from SMPTE ST2065-1
-    {
-        {0.73470, 0.26530},
-        {0.00000, 1.00000},
-        {0.00010, -0.07700},
-        {0.32168, 0.33767}};
-
-const Chromaticities ARRI_ALEXA_WG_PRI =
-    {
-        {0.68400, 0.31300},
-        {0.22100, 0.84800},
-        {0.08610, -0.10200},
-        {0.31270, 0.32900}};
-
-const float AWG3_to_AP0_MAT[3][3] = calculate_rgb_to_rgb_matrix(ARRI_ALEXA_WG_PRI,
-                                                                AP0,
-                                                                CONE_RESP_MAT_CAT02);
 
 const float EI = 2000.0;
 

--- a/arri/CSC.Arri.LogCv3-EI200_to_ACES.ctl
+++ b/arri/CSC.Arri.LogCv3-EI200_to_ACES.ctl
@@ -1,16 +1,14 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Contributors to the ACES Project.
 
-// <ACEStransformID>urn:ampas:aces:transformId:v2.0:CSC.Arri.LogC3_to_ACES.a2.v1</ACEStransformID>
-// <ACESuserName>ARRI LogC3 to ACES2065-1</ACESuserName>
+// <ACEStransformID>urn:ampas:aces:transformId:v2.0:CSC.Arri.LogC3-EI200_to_ACES.a2.v1</ACEStransformID>
+// <ACESuserName>ARRI LogC3 EI200 to ACES2065-1</ACESuserName>
 
 //
-// ACES Color Space Conversion - Arri LogC3 to ACES2065-1
+// ACES Color Space Conversion - Arri LogC3 EI200 to ACES2065-1
 //
-// converts Arri LogC3 to
+// converts Arri LogC3 EI200 to
 //          ACES2065-1 (AP0 w/ linear encoding)
-//
-// NOTE: In this transform EI is a parameter, defaulted to EI800.
 //
 
 import "Lib.Academy.Utilities";
@@ -116,7 +114,7 @@ void main(input varying float rIn,
           output varying float gOut,
           output varying float bOut,
           output varying float aOut,
-          input uniform float EI = 800.0)
+          input uniform float EI = 200.0)
 {
     float lin_AWG3[3];
     lin_AWG3[0] = normalizedLogC3ToRelativeExposure(rIn, EI);

--- a/arri/CSC.Arri.LogCv3-EI200_to_ACES.ctl
+++ b/arri/CSC.Arri.LogCv3-EI200_to_ACES.ctl
@@ -13,6 +13,7 @@
 
 import "Lib.Academy.Utilities";
 import "Lib.Academy.ColorSpaces";
+import "Lib.Arri.LogC3";
 
 const Chromaticities AP0 = // ACES Primaries from SMPTE ST2065-1
     {
@@ -32,79 +33,7 @@ const float AWG3_to_AP0_MAT[3][3] = calculate_rgb_to_rgb_matrix(ARRI_ALEXA_WG_PR
                                                                 AP0,
                                                                 CONE_RESP_MAT_CAT02);
 
-const float nominalEI = 400.0;
-const float blackSignal = 16.0 / 4095.0;
-const float midGraySignal = 0.01;
-const float encodingGain = 500.0 / 1023.0 * 0.525;
-const float encodingOffset = 400.0 / 1023.0;
-const float cut = 1.0 / 9.0;
-const float slope = 1.0 / (cut * log(10.0));
-const float offset = log10(cut) - slope * cut;
-
-float[4] hermiteWeights(float x, float x1, float x2)
-{
-    const float d = x2 - x1;
-    const float s = (x - x1) / d;
-    const float s2 = 1.0 - s;
-    float out[4];
-    out[0] = (1.0 + 2.0 * s) * s2 * s2;
-    out[1] = (3.0 - 2.0 * s) * s * s;
-    out[2] = d * s * s2 * s2;
-    out[3] = -d * s * s * s2;
-    return out;
-}
-
-float normalizedSensorToRelativeExposure(float ns, float EI)
-{
-    return (ns - blackSignal) * (0.18 / (midGraySignal * nominalEI / EI));
-}
-
-float normalizedLogC3ToRelativeExposure(float t, float EI)
-{
-    float nz;
-    float out;
-    float ns;
-    const float gain = EI / nominalEI;
-    const float gray = midGraySignal / gain;
-    const float encGain = (log2(gain) * (0.89 - 1.0) / 3.0 + 1.0) * encodingGain;
-    float encOffset = encodingOffset;
-    for (int i = 0; i < 3; i = i + 1)
-    {
-        nz = ((95.0 / 1023.0 - encOffset) / encGain - offset) / slope;
-        encOffset = encodingOffset - log10(1.0 + nz) * encGain;
-    }
-    float xm = log10((1.0 - blackSignal) / gray + nz) * encGain + encOffset;
-    if (xm > 1)
-    {
-        float hw[4] = hermiteWeights(t, 0.8, 1.0);
-        float d = 0.2 / (xm - 0.8);
-        float v[4];
-        v[0] = 0.8;
-        v[1] = xm;
-        v[2] = 1.0;
-        v[3] = 1.0 / (d * d);
-        if (t <= 0.8)
-        {
-            out = t;
-        }
-        else
-        {
-            out = hw[0] * v[0] + hw[1] * v[1] + hw[2] * v[2] + hw[3] * v[3];
-        }
-    }
-    else
-    {
-        out = t;
-    }
-    out = (out - encOffset) / encGain;
-    ns = (out - offset) / slope;
-    if (ns > cut)
-    {
-        ns = pow(10.0, out);
-    }
-    ns = (ns - nz) * gray + blackSignal;
-    return normalizedSensorToRelativeExposure(ns, EI);
-}
+const float EI = 200.0;
 
 void main(input varying float rIn,
           input varying float gIn,
@@ -113,8 +42,7 @@ void main(input varying float rIn,
           output varying float rOut,
           output varying float gOut,
           output varying float bOut,
-          output varying float aOut,
-          input uniform float EI = 200.0)
+          output varying float aOut)
 {
     float lin_AWG3[3];
     lin_AWG3[0] = normalizedLogC3ToRelativeExposure(rIn, EI);

--- a/arri/CSC.Arri.LogCv3-EI200_to_ACES.ctl
+++ b/arri/CSC.Arri.LogCv3-EI200_to_ACES.ctl
@@ -12,26 +12,7 @@
 //
 
 import "Lib.Academy.Utilities";
-import "Lib.Academy.ColorSpaces";
 import "Lib.Arri.LogC3";
-
-const Chromaticities AP0 = // ACES Primaries from SMPTE ST2065-1
-    {
-        {0.73470, 0.26530},
-        {0.00000, 1.00000},
-        {0.00010, -0.07700},
-        {0.32168, 0.33767}};
-
-const Chromaticities ARRI_ALEXA_WG_PRI =
-    {
-        {0.68400, 0.31300},
-        {0.22100, 0.84800},
-        {0.08610, -0.10200},
-        {0.31270, 0.32900}};
-
-const float AWG3_to_AP0_MAT[3][3] = calculate_rgb_to_rgb_matrix(ARRI_ALEXA_WG_PRI,
-                                                                AP0,
-                                                                CONE_RESP_MAT_CAT02);
 
 const float EI = 200.0;
 

--- a/arri/CSC.Arri.LogCv3-EI250_to_ACES.ctl
+++ b/arri/CSC.Arri.LogCv3-EI250_to_ACES.ctl
@@ -13,6 +13,7 @@
 
 import "Lib.Academy.Utilities";
 import "Lib.Academy.ColorSpaces";
+import "Lib.Arri.LogC3";
 
 const Chromaticities AP0 = // ACES Primaries from SMPTE ST2065-1
     {
@@ -32,79 +33,7 @@ const float AWG3_to_AP0_MAT[3][3] = calculate_rgb_to_rgb_matrix(ARRI_ALEXA_WG_PR
                                                                 AP0,
                                                                 CONE_RESP_MAT_CAT02);
 
-const float nominalEI = 400.0;
-const float blackSignal = 16.0 / 4095.0;
-const float midGraySignal = 0.01;
-const float encodingGain = 500.0 / 1023.0 * 0.525;
-const float encodingOffset = 400.0 / 1023.0;
-const float cut = 1.0 / 9.0;
-const float slope = 1.0 / (cut * log(10.0));
-const float offset = log10(cut) - slope * cut;
-
-float[4] hermiteWeights(float x, float x1, float x2)
-{
-    const float d = x2 - x1;
-    const float s = (x - x1) / d;
-    const float s2 = 1.0 - s;
-    float out[4];
-    out[0] = (1.0 + 2.0 * s) * s2 * s2;
-    out[1] = (3.0 - 2.0 * s) * s * s;
-    out[2] = d * s * s2 * s2;
-    out[3] = -d * s * s * s2;
-    return out;
-}
-
-float normalizedSensorToRelativeExposure(float ns, float EI)
-{
-    return (ns - blackSignal) * (0.18 / (midGraySignal * nominalEI / EI));
-}
-
-float normalizedLogC3ToRelativeExposure(float t, float EI)
-{
-    float nz;
-    float out;
-    float ns;
-    const float gain = EI / nominalEI;
-    const float gray = midGraySignal / gain;
-    const float encGain = (log2(gain) * (0.89 - 1.0) / 3.0 + 1.0) * encodingGain;
-    float encOffset = encodingOffset;
-    for (int i = 0; i < 3; i = i + 1)
-    {
-        nz = ((95.0 / 1023.0 - encOffset) / encGain - offset) / slope;
-        encOffset = encodingOffset - log10(1.0 + nz) * encGain;
-    }
-    float xm = log10((1.0 - blackSignal) / gray + nz) * encGain + encOffset;
-    if (xm > 1)
-    {
-        float hw[4] = hermiteWeights(t, 0.8, 1.0);
-        float d = 0.2 / (xm - 0.8);
-        float v[4];
-        v[0] = 0.8;
-        v[1] = xm;
-        v[2] = 1.0;
-        v[3] = 1.0 / (d * d);
-        if (t <= 0.8)
-        {
-            out = t;
-        }
-        else
-        {
-            out = hw[0] * v[0] + hw[1] * v[1] + hw[2] * v[2] + hw[3] * v[3];
-        }
-    }
-    else
-    {
-        out = t;
-    }
-    out = (out - encOffset) / encGain;
-    ns = (out - offset) / slope;
-    if (ns > cut)
-    {
-        ns = pow(10.0, out);
-    }
-    ns = (ns - nz) * gray + blackSignal;
-    return normalizedSensorToRelativeExposure(ns, EI);
-}
+const float EI = 250.0;
 
 void main(input varying float rIn,
           input varying float gIn,
@@ -113,8 +42,7 @@ void main(input varying float rIn,
           output varying float rOut,
           output varying float gOut,
           output varying float bOut,
-          output varying float aOut,
-          input uniform float EI = 250.0)
+          output varying float aOut)
 {
     float lin_AWG3[3];
     lin_AWG3[0] = normalizedLogC3ToRelativeExposure(rIn, EI);

--- a/arri/CSC.Arri.LogCv3-EI250_to_ACES.ctl
+++ b/arri/CSC.Arri.LogCv3-EI250_to_ACES.ctl
@@ -1,16 +1,14 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Contributors to the ACES Project.
 
-// <ACEStransformID>urn:ampas:aces:transformId:v2.0:CSC.Arri.LogC3_to_ACES.a2.v1</ACEStransformID>
-// <ACESuserName>ARRI LogC3 to ACES2065-1</ACESuserName>
+// <ACEStransformID>urn:ampas:aces:transformId:v2.0:CSC.Arri.LogC3-EI250_to_ACES.a2.v1</ACEStransformID>
+// <ACESuserName>ARRI LogC3 EI250 to ACES2065-1</ACESuserName>
 
 //
-// ACES Color Space Conversion - Arri LogC3 to ACES2065-1
+// ACES Color Space Conversion - Arri LogC3 EI250 to ACES2065-1
 //
-// converts Arri LogC3 to
+// converts Arri LogC3 EI250 to
 //          ACES2065-1 (AP0 w/ linear encoding)
-//
-// NOTE: In this transform EI is a parameter, defaulted to EI800.
 //
 
 import "Lib.Academy.Utilities";
@@ -116,7 +114,7 @@ void main(input varying float rIn,
           output varying float gOut,
           output varying float bOut,
           output varying float aOut,
-          input uniform float EI = 800.0)
+          input uniform float EI = 250.0)
 {
     float lin_AWG3[3];
     lin_AWG3[0] = normalizedLogC3ToRelativeExposure(rIn, EI);

--- a/arri/CSC.Arri.LogCv3-EI250_to_ACES.ctl
+++ b/arri/CSC.Arri.LogCv3-EI250_to_ACES.ctl
@@ -12,26 +12,7 @@
 //
 
 import "Lib.Academy.Utilities";
-import "Lib.Academy.ColorSpaces";
 import "Lib.Arri.LogC3";
-
-const Chromaticities AP0 = // ACES Primaries from SMPTE ST2065-1
-    {
-        {0.73470, 0.26530},
-        {0.00000, 1.00000},
-        {0.00010, -0.07700},
-        {0.32168, 0.33767}};
-
-const Chromaticities ARRI_ALEXA_WG_PRI =
-    {
-        {0.68400, 0.31300},
-        {0.22100, 0.84800},
-        {0.08610, -0.10200},
-        {0.31270, 0.32900}};
-
-const float AWG3_to_AP0_MAT[3][3] = calculate_rgb_to_rgb_matrix(ARRI_ALEXA_WG_PRI,
-                                                                AP0,
-                                                                CONE_RESP_MAT_CAT02);
 
 const float EI = 250.0;
 

--- a/arri/CSC.Arri.LogCv3-EI2560_to_ACES.ctl
+++ b/arri/CSC.Arri.LogCv3-EI2560_to_ACES.ctl
@@ -1,16 +1,14 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Contributors to the ACES Project.
 
-// <ACEStransformID>urn:ampas:aces:transformId:v2.0:CSC.Arri.LogC3_to_ACES.a2.v1</ACEStransformID>
-// <ACESuserName>ARRI LogC3 to ACES2065-1</ACESuserName>
+// <ACEStransformID>urn:ampas:aces:transformId:v2.0:CSC.Arri.LogC3-EI2560_to_ACES.a2.v1</ACEStransformID>
+// <ACESuserName>ARRI LogC3 EI2560 to ACES2065-1</ACESuserName>
 
 //
-// ACES Color Space Conversion - Arri LogC3 to ACES2065-1
+// ACES Color Space Conversion - Arri LogC3 EI2560 to ACES2065-1
 //
-// converts Arri LogC3 to
+// converts Arri LogC3 EI2560 to
 //          ACES2065-1 (AP0 w/ linear encoding)
-//
-// NOTE: In this transform EI is a parameter, defaulted to EI800.
 //
 
 import "Lib.Academy.Utilities";
@@ -116,7 +114,7 @@ void main(input varying float rIn,
           output varying float gOut,
           output varying float bOut,
           output varying float aOut,
-          input uniform float EI = 800.0)
+          input uniform float EI = 2560.0)
 {
     float lin_AWG3[3];
     lin_AWG3[0] = normalizedLogC3ToRelativeExposure(rIn, EI);

--- a/arri/CSC.Arri.LogCv3-EI2560_to_ACES.ctl
+++ b/arri/CSC.Arri.LogCv3-EI2560_to_ACES.ctl
@@ -13,6 +13,7 @@
 
 import "Lib.Academy.Utilities";
 import "Lib.Academy.ColorSpaces";
+import "Lib.Arri.LogC3";
 
 const Chromaticities AP0 = // ACES Primaries from SMPTE ST2065-1
     {
@@ -32,79 +33,7 @@ const float AWG3_to_AP0_MAT[3][3] = calculate_rgb_to_rgb_matrix(ARRI_ALEXA_WG_PR
                                                                 AP0,
                                                                 CONE_RESP_MAT_CAT02);
 
-const float nominalEI = 400.0;
-const float blackSignal = 16.0 / 4095.0;
-const float midGraySignal = 0.01;
-const float encodingGain = 500.0 / 1023.0 * 0.525;
-const float encodingOffset = 400.0 / 1023.0;
-const float cut = 1.0 / 9.0;
-const float slope = 1.0 / (cut * log(10.0));
-const float offset = log10(cut) - slope * cut;
-
-float[4] hermiteWeights(float x, float x1, float x2)
-{
-    const float d = x2 - x1;
-    const float s = (x - x1) / d;
-    const float s2 = 1.0 - s;
-    float out[4];
-    out[0] = (1.0 + 2.0 * s) * s2 * s2;
-    out[1] = (3.0 - 2.0 * s) * s * s;
-    out[2] = d * s * s2 * s2;
-    out[3] = -d * s * s * s2;
-    return out;
-}
-
-float normalizedSensorToRelativeExposure(float ns, float EI)
-{
-    return (ns - blackSignal) * (0.18 / (midGraySignal * nominalEI / EI));
-}
-
-float normalizedLogC3ToRelativeExposure(float t, float EI)
-{
-    float nz;
-    float out;
-    float ns;
-    const float gain = EI / nominalEI;
-    const float gray = midGraySignal / gain;
-    const float encGain = (log2(gain) * (0.89 - 1.0) / 3.0 + 1.0) * encodingGain;
-    float encOffset = encodingOffset;
-    for (int i = 0; i < 3; i = i + 1)
-    {
-        nz = ((95.0 / 1023.0 - encOffset) / encGain - offset) / slope;
-        encOffset = encodingOffset - log10(1.0 + nz) * encGain;
-    }
-    float xm = log10((1.0 - blackSignal) / gray + nz) * encGain + encOffset;
-    if (xm > 1)
-    {
-        float hw[4] = hermiteWeights(t, 0.8, 1.0);
-        float d = 0.2 / (xm - 0.8);
-        float v[4];
-        v[0] = 0.8;
-        v[1] = xm;
-        v[2] = 1.0;
-        v[3] = 1.0 / (d * d);
-        if (t <= 0.8)
-        {
-            out = t;
-        }
-        else
-        {
-            out = hw[0] * v[0] + hw[1] * v[1] + hw[2] * v[2] + hw[3] * v[3];
-        }
-    }
-    else
-    {
-        out = t;
-    }
-    out = (out - encOffset) / encGain;
-    ns = (out - offset) / slope;
-    if (ns > cut)
-    {
-        ns = pow(10.0, out);
-    }
-    ns = (ns - nz) * gray + blackSignal;
-    return normalizedSensorToRelativeExposure(ns, EI);
-}
+const float EI = 2560.0;
 
 void main(input varying float rIn,
           input varying float gIn,
@@ -113,8 +42,7 @@ void main(input varying float rIn,
           output varying float rOut,
           output varying float gOut,
           output varying float bOut,
-          output varying float aOut,
-          input uniform float EI = 2560.0)
+          output varying float aOut)
 {
     float lin_AWG3[3];
     lin_AWG3[0] = normalizedLogC3ToRelativeExposure(rIn, EI);

--- a/arri/CSC.Arri.LogCv3-EI2560_to_ACES.ctl
+++ b/arri/CSC.Arri.LogCv3-EI2560_to_ACES.ctl
@@ -12,26 +12,7 @@
 //
 
 import "Lib.Academy.Utilities";
-import "Lib.Academy.ColorSpaces";
 import "Lib.Arri.LogC3";
-
-const Chromaticities AP0 = // ACES Primaries from SMPTE ST2065-1
-    {
-        {0.73470, 0.26530},
-        {0.00000, 1.00000},
-        {0.00010, -0.07700},
-        {0.32168, 0.33767}};
-
-const Chromaticities ARRI_ALEXA_WG_PRI =
-    {
-        {0.68400, 0.31300},
-        {0.22100, 0.84800},
-        {0.08610, -0.10200},
-        {0.31270, 0.32900}};
-
-const float AWG3_to_AP0_MAT[3][3] = calculate_rgb_to_rgb_matrix(ARRI_ALEXA_WG_PRI,
-                                                                AP0,
-                                                                CONE_RESP_MAT_CAT02);
 
 const float EI = 2560.0;
 

--- a/arri/CSC.Arri.LogCv3-EI3200_to_ACES.ctl
+++ b/arri/CSC.Arri.LogCv3-EI3200_to_ACES.ctl
@@ -1,16 +1,14 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Contributors to the ACES Project.
 
-// <ACEStransformID>urn:ampas:aces:transformId:v2.0:CSC.Arri.LogC3_to_ACES.a2.v1</ACEStransformID>
-// <ACESuserName>ARRI LogC3 to ACES2065-1</ACESuserName>
+// <ACEStransformID>urn:ampas:aces:transformId:v2.0:CSC.Arri.LogC3-EI3200_to_ACES.a2.v1</ACEStransformID>
+// <ACESuserName>ARRI LogC3 E13200 to ACES2065-1</ACESuserName>
 
 //
-// ACES Color Space Conversion - Arri LogC3 to ACES2065-1
+// ACES Color Space Conversion - Arri LogC3 EI3200 to ACES2065-1
 //
-// converts Arri LogC3 to
+// converts Arri LogC3 EI3200 to
 //          ACES2065-1 (AP0 w/ linear encoding)
-//
-// NOTE: In this transform EI is a parameter, defaulted to EI800.
 //
 
 import "Lib.Academy.Utilities";
@@ -116,7 +114,7 @@ void main(input varying float rIn,
           output varying float gOut,
           output varying float bOut,
           output varying float aOut,
-          input uniform float EI = 800.0)
+          input uniform float EI = 3200.0)
 {
     float lin_AWG3[3];
     lin_AWG3[0] = normalizedLogC3ToRelativeExposure(rIn, EI);

--- a/arri/CSC.Arri.LogCv3-EI3200_to_ACES.ctl
+++ b/arri/CSC.Arri.LogCv3-EI3200_to_ACES.ctl
@@ -13,6 +13,7 @@
 
 import "Lib.Academy.Utilities";
 import "Lib.Academy.ColorSpaces";
+import "Lib.Arri.LogC3";
 
 const Chromaticities AP0 = // ACES Primaries from SMPTE ST2065-1
     {
@@ -32,79 +33,7 @@ const float AWG3_to_AP0_MAT[3][3] = calculate_rgb_to_rgb_matrix(ARRI_ALEXA_WG_PR
                                                                 AP0,
                                                                 CONE_RESP_MAT_CAT02);
 
-const float nominalEI = 400.0;
-const float blackSignal = 16.0 / 4095.0;
-const float midGraySignal = 0.01;
-const float encodingGain = 500.0 / 1023.0 * 0.525;
-const float encodingOffset = 400.0 / 1023.0;
-const float cut = 1.0 / 9.0;
-const float slope = 1.0 / (cut * log(10.0));
-const float offset = log10(cut) - slope * cut;
-
-float[4] hermiteWeights(float x, float x1, float x2)
-{
-    const float d = x2 - x1;
-    const float s = (x - x1) / d;
-    const float s2 = 1.0 - s;
-    float out[4];
-    out[0] = (1.0 + 2.0 * s) * s2 * s2;
-    out[1] = (3.0 - 2.0 * s) * s * s;
-    out[2] = d * s * s2 * s2;
-    out[3] = -d * s * s * s2;
-    return out;
-}
-
-float normalizedSensorToRelativeExposure(float ns, float EI)
-{
-    return (ns - blackSignal) * (0.18 / (midGraySignal * nominalEI / EI));
-}
-
-float normalizedLogC3ToRelativeExposure(float t, float EI)
-{
-    float nz;
-    float out;
-    float ns;
-    const float gain = EI / nominalEI;
-    const float gray = midGraySignal / gain;
-    const float encGain = (log2(gain) * (0.89 - 1.0) / 3.0 + 1.0) * encodingGain;
-    float encOffset = encodingOffset;
-    for (int i = 0; i < 3; i = i + 1)
-    {
-        nz = ((95.0 / 1023.0 - encOffset) / encGain - offset) / slope;
-        encOffset = encodingOffset - log10(1.0 + nz) * encGain;
-    }
-    float xm = log10((1.0 - blackSignal) / gray + nz) * encGain + encOffset;
-    if (xm > 1)
-    {
-        float hw[4] = hermiteWeights(t, 0.8, 1.0);
-        float d = 0.2 / (xm - 0.8);
-        float v[4];
-        v[0] = 0.8;
-        v[1] = xm;
-        v[2] = 1.0;
-        v[3] = 1.0 / (d * d);
-        if (t <= 0.8)
-        {
-            out = t;
-        }
-        else
-        {
-            out = hw[0] * v[0] + hw[1] * v[1] + hw[2] * v[2] + hw[3] * v[3];
-        }
-    }
-    else
-    {
-        out = t;
-    }
-    out = (out - encOffset) / encGain;
-    ns = (out - offset) / slope;
-    if (ns > cut)
-    {
-        ns = pow(10.0, out);
-    }
-    ns = (ns - nz) * gray + blackSignal;
-    return normalizedSensorToRelativeExposure(ns, EI);
-}
+const float EI = 3200.0;
 
 void main(input varying float rIn,
           input varying float gIn,
@@ -113,8 +42,7 @@ void main(input varying float rIn,
           output varying float rOut,
           output varying float gOut,
           output varying float bOut,
-          output varying float aOut,
-          input uniform float EI = 3200.0)
+          output varying float aOut)
 {
     float lin_AWG3[3];
     lin_AWG3[0] = normalizedLogC3ToRelativeExposure(rIn, EI);

--- a/arri/CSC.Arri.LogCv3-EI3200_to_ACES.ctl
+++ b/arri/CSC.Arri.LogCv3-EI3200_to_ACES.ctl
@@ -12,26 +12,7 @@
 //
 
 import "Lib.Academy.Utilities";
-import "Lib.Academy.ColorSpaces";
 import "Lib.Arri.LogC3";
-
-const Chromaticities AP0 = // ACES Primaries from SMPTE ST2065-1
-    {
-        {0.73470, 0.26530},
-        {0.00000, 1.00000},
-        {0.00010, -0.07700},
-        {0.32168, 0.33767}};
-
-const Chromaticities ARRI_ALEXA_WG_PRI =
-    {
-        {0.68400, 0.31300},
-        {0.22100, 0.84800},
-        {0.08610, -0.10200},
-        {0.31270, 0.32900}};
-
-const float AWG3_to_AP0_MAT[3][3] = calculate_rgb_to_rgb_matrix(ARRI_ALEXA_WG_PRI,
-                                                                AP0,
-                                                                CONE_RESP_MAT_CAT02);
 
 const float EI = 3200.0;
 

--- a/arri/CSC.Arri.LogCv3-EI320_to_ACES.ctl
+++ b/arri/CSC.Arri.LogCv3-EI320_to_ACES.ctl
@@ -1,16 +1,14 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Contributors to the ACES Project.
 
-// <ACEStransformID>urn:ampas:aces:transformId:v2.0:CSC.Arri.LogC3_to_ACES.a2.v1</ACEStransformID>
-// <ACESuserName>ARRI LogC3 to ACES2065-1</ACESuserName>
+// <ACEStransformID>urn:ampas:aces:transformId:v2.0:CSC.Arri.LogC3-EI320_to_ACES.a2.v1</ACEStransformID>
+// <ACESuserName>ARRI LogC3 EI320 to ACES2065-1</ACESuserName>
 
 //
-// ACES Color Space Conversion - Arri LogC3 to ACES2065-1
+// ACES Color Space Conversion - Arri LogC3 EI320 to ACES2065-1
 //
-// converts Arri LogC3 to
+// converts Arri LogC3 EI320 to
 //          ACES2065-1 (AP0 w/ linear encoding)
-//
-// NOTE: In this transform EI is a parameter, defaulted to EI800.
 //
 
 import "Lib.Academy.Utilities";
@@ -116,7 +114,7 @@ void main(input varying float rIn,
           output varying float gOut,
           output varying float bOut,
           output varying float aOut,
-          input uniform float EI = 800.0)
+          input uniform float EI = 320.0)
 {
     float lin_AWG3[3];
     lin_AWG3[0] = normalizedLogC3ToRelativeExposure(rIn, EI);

--- a/arri/CSC.Arri.LogCv3-EI320_to_ACES.ctl
+++ b/arri/CSC.Arri.LogCv3-EI320_to_ACES.ctl
@@ -13,6 +13,7 @@
 
 import "Lib.Academy.Utilities";
 import "Lib.Academy.ColorSpaces";
+import "Lib.Arri.LogC3";
 
 const Chromaticities AP0 = // ACES Primaries from SMPTE ST2065-1
     {
@@ -32,79 +33,7 @@ const float AWG3_to_AP0_MAT[3][3] = calculate_rgb_to_rgb_matrix(ARRI_ALEXA_WG_PR
                                                                 AP0,
                                                                 CONE_RESP_MAT_CAT02);
 
-const float nominalEI = 400.0;
-const float blackSignal = 16.0 / 4095.0;
-const float midGraySignal = 0.01;
-const float encodingGain = 500.0 / 1023.0 * 0.525;
-const float encodingOffset = 400.0 / 1023.0;
-const float cut = 1.0 / 9.0;
-const float slope = 1.0 / (cut * log(10.0));
-const float offset = log10(cut) - slope * cut;
-
-float[4] hermiteWeights(float x, float x1, float x2)
-{
-    const float d = x2 - x1;
-    const float s = (x - x1) / d;
-    const float s2 = 1.0 - s;
-    float out[4];
-    out[0] = (1.0 + 2.0 * s) * s2 * s2;
-    out[1] = (3.0 - 2.0 * s) * s * s;
-    out[2] = d * s * s2 * s2;
-    out[3] = -d * s * s * s2;
-    return out;
-}
-
-float normalizedSensorToRelativeExposure(float ns, float EI)
-{
-    return (ns - blackSignal) * (0.18 / (midGraySignal * nominalEI / EI));
-}
-
-float normalizedLogC3ToRelativeExposure(float t, float EI)
-{
-    float nz;
-    float out;
-    float ns;
-    const float gain = EI / nominalEI;
-    const float gray = midGraySignal / gain;
-    const float encGain = (log2(gain) * (0.89 - 1.0) / 3.0 + 1.0) * encodingGain;
-    float encOffset = encodingOffset;
-    for (int i = 0; i < 3; i = i + 1)
-    {
-        nz = ((95.0 / 1023.0 - encOffset) / encGain - offset) / slope;
-        encOffset = encodingOffset - log10(1.0 + nz) * encGain;
-    }
-    float xm = log10((1.0 - blackSignal) / gray + nz) * encGain + encOffset;
-    if (xm > 1)
-    {
-        float hw[4] = hermiteWeights(t, 0.8, 1.0);
-        float d = 0.2 / (xm - 0.8);
-        float v[4];
-        v[0] = 0.8;
-        v[1] = xm;
-        v[2] = 1.0;
-        v[3] = 1.0 / (d * d);
-        if (t <= 0.8)
-        {
-            out = t;
-        }
-        else
-        {
-            out = hw[0] * v[0] + hw[1] * v[1] + hw[2] * v[2] + hw[3] * v[3];
-        }
-    }
-    else
-    {
-        out = t;
-    }
-    out = (out - encOffset) / encGain;
-    ns = (out - offset) / slope;
-    if (ns > cut)
-    {
-        ns = pow(10.0, out);
-    }
-    ns = (ns - nz) * gray + blackSignal;
-    return normalizedSensorToRelativeExposure(ns, EI);
-}
+const float EI = 320.0;
 
 void main(input varying float rIn,
           input varying float gIn,
@@ -113,8 +42,7 @@ void main(input varying float rIn,
           output varying float rOut,
           output varying float gOut,
           output varying float bOut,
-          output varying float aOut,
-          input uniform float EI = 320.0)
+          output varying float aOut)
 {
     float lin_AWG3[3];
     lin_AWG3[0] = normalizedLogC3ToRelativeExposure(rIn, EI);

--- a/arri/CSC.Arri.LogCv3-EI320_to_ACES.ctl
+++ b/arri/CSC.Arri.LogCv3-EI320_to_ACES.ctl
@@ -12,26 +12,7 @@
 //
 
 import "Lib.Academy.Utilities";
-import "Lib.Academy.ColorSpaces";
 import "Lib.Arri.LogC3";
-
-const Chromaticities AP0 = // ACES Primaries from SMPTE ST2065-1
-    {
-        {0.73470, 0.26530},
-        {0.00000, 1.00000},
-        {0.00010, -0.07700},
-        {0.32168, 0.33767}};
-
-const Chromaticities ARRI_ALEXA_WG_PRI =
-    {
-        {0.68400, 0.31300},
-        {0.22100, 0.84800},
-        {0.08610, -0.10200},
-        {0.31270, 0.32900}};
-
-const float AWG3_to_AP0_MAT[3][3] = calculate_rgb_to_rgb_matrix(ARRI_ALEXA_WG_PRI,
-                                                                AP0,
-                                                                CONE_RESP_MAT_CAT02);
 
 const float EI = 320.0;
 

--- a/arri/CSC.Arri.LogCv3-EI400_to_ACES.ctl
+++ b/arri/CSC.Arri.LogCv3-EI400_to_ACES.ctl
@@ -1,16 +1,14 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Contributors to the ACES Project.
 
-// <ACEStransformID>urn:ampas:aces:transformId:v2.0:CSC.Arri.LogC3_to_ACES.a2.v1</ACEStransformID>
-// <ACESuserName>ARRI LogC3 to ACES2065-1</ACESuserName>
+// <ACEStransformID>urn:ampas:aces:transformId:v2.0:CSC.Arri.LogC3-EI400_to_ACES.a2.v1</ACEStransformID>
+// <ACESuserName>ARRI LogC3 EI400 to ACES2065-1</ACESuserName>
 
 //
-// ACES Color Space Conversion - Arri LogC3 to ACES2065-1
+// ACES Color Space Conversion - Arri LogC3 EI400 to ACES2065-1
 //
-// converts Arri LogC3 to
+// converts Arri LogC3 EI400 to
 //          ACES2065-1 (AP0 w/ linear encoding)
-//
-// NOTE: In this transform EI is a parameter, defaulted to EI800.
 //
 
 import "Lib.Academy.Utilities";
@@ -116,7 +114,7 @@ void main(input varying float rIn,
           output varying float gOut,
           output varying float bOut,
           output varying float aOut,
-          input uniform float EI = 800.0)
+          input uniform float EI = 400.0)
 {
     float lin_AWG3[3];
     lin_AWG3[0] = normalizedLogC3ToRelativeExposure(rIn, EI);

--- a/arri/CSC.Arri.LogCv3-EI400_to_ACES.ctl
+++ b/arri/CSC.Arri.LogCv3-EI400_to_ACES.ctl
@@ -13,6 +13,7 @@
 
 import "Lib.Academy.Utilities";
 import "Lib.Academy.ColorSpaces";
+import "Lib.Arri.LogC3";
 
 const Chromaticities AP0 = // ACES Primaries from SMPTE ST2065-1
     {
@@ -32,79 +33,7 @@ const float AWG3_to_AP0_MAT[3][3] = calculate_rgb_to_rgb_matrix(ARRI_ALEXA_WG_PR
                                                                 AP0,
                                                                 CONE_RESP_MAT_CAT02);
 
-const float nominalEI = 400.0;
-const float blackSignal = 16.0 / 4095.0;
-const float midGraySignal = 0.01;
-const float encodingGain = 500.0 / 1023.0 * 0.525;
-const float encodingOffset = 400.0 / 1023.0;
-const float cut = 1.0 / 9.0;
-const float slope = 1.0 / (cut * log(10.0));
-const float offset = log10(cut) - slope * cut;
-
-float[4] hermiteWeights(float x, float x1, float x2)
-{
-    const float d = x2 - x1;
-    const float s = (x - x1) / d;
-    const float s2 = 1.0 - s;
-    float out[4];
-    out[0] = (1.0 + 2.0 * s) * s2 * s2;
-    out[1] = (3.0 - 2.0 * s) * s * s;
-    out[2] = d * s * s2 * s2;
-    out[3] = -d * s * s * s2;
-    return out;
-}
-
-float normalizedSensorToRelativeExposure(float ns, float EI)
-{
-    return (ns - blackSignal) * (0.18 / (midGraySignal * nominalEI / EI));
-}
-
-float normalizedLogC3ToRelativeExposure(float t, float EI)
-{
-    float nz;
-    float out;
-    float ns;
-    const float gain = EI / nominalEI;
-    const float gray = midGraySignal / gain;
-    const float encGain = (log2(gain) * (0.89 - 1.0) / 3.0 + 1.0) * encodingGain;
-    float encOffset = encodingOffset;
-    for (int i = 0; i < 3; i = i + 1)
-    {
-        nz = ((95.0 / 1023.0 - encOffset) / encGain - offset) / slope;
-        encOffset = encodingOffset - log10(1.0 + nz) * encGain;
-    }
-    float xm = log10((1.0 - blackSignal) / gray + nz) * encGain + encOffset;
-    if (xm > 1)
-    {
-        float hw[4] = hermiteWeights(t, 0.8, 1.0);
-        float d = 0.2 / (xm - 0.8);
-        float v[4];
-        v[0] = 0.8;
-        v[1] = xm;
-        v[2] = 1.0;
-        v[3] = 1.0 / (d * d);
-        if (t <= 0.8)
-        {
-            out = t;
-        }
-        else
-        {
-            out = hw[0] * v[0] + hw[1] * v[1] + hw[2] * v[2] + hw[3] * v[3];
-        }
-    }
-    else
-    {
-        out = t;
-    }
-    out = (out - encOffset) / encGain;
-    ns = (out - offset) / slope;
-    if (ns > cut)
-    {
-        ns = pow(10.0, out);
-    }
-    ns = (ns - nz) * gray + blackSignal;
-    return normalizedSensorToRelativeExposure(ns, EI);
-}
+const float EI = 400.0;
 
 void main(input varying float rIn,
           input varying float gIn,
@@ -113,8 +42,7 @@ void main(input varying float rIn,
           output varying float rOut,
           output varying float gOut,
           output varying float bOut,
-          output varying float aOut,
-          input uniform float EI = 400.0)
+          output varying float aOut)
 {
     float lin_AWG3[3];
     lin_AWG3[0] = normalizedLogC3ToRelativeExposure(rIn, EI);

--- a/arri/CSC.Arri.LogCv3-EI400_to_ACES.ctl
+++ b/arri/CSC.Arri.LogCv3-EI400_to_ACES.ctl
@@ -12,26 +12,7 @@
 //
 
 import "Lib.Academy.Utilities";
-import "Lib.Academy.ColorSpaces";
 import "Lib.Arri.LogC3";
-
-const Chromaticities AP0 = // ACES Primaries from SMPTE ST2065-1
-    {
-        {0.73470, 0.26530},
-        {0.00000, 1.00000},
-        {0.00010, -0.07700},
-        {0.32168, 0.33767}};
-
-const Chromaticities ARRI_ALEXA_WG_PRI =
-    {
-        {0.68400, 0.31300},
-        {0.22100, 0.84800},
-        {0.08610, -0.10200},
-        {0.31270, 0.32900}};
-
-const float AWG3_to_AP0_MAT[3][3] = calculate_rgb_to_rgb_matrix(ARRI_ALEXA_WG_PRI,
-                                                                AP0,
-                                                                CONE_RESP_MAT_CAT02);
 
 const float EI = 400.0;
 

--- a/arri/CSC.Arri.LogCv3-EI500_to_ACES.ctl
+++ b/arri/CSC.Arri.LogCv3-EI500_to_ACES.ctl
@@ -13,6 +13,7 @@
 
 import "Lib.Academy.Utilities";
 import "Lib.Academy.ColorSpaces";
+import "Lib.Arri.LogC3";
 
 const Chromaticities AP0 = // ACES Primaries from SMPTE ST2065-1
     {
@@ -32,79 +33,7 @@ const float AWG3_to_AP0_MAT[3][3] = calculate_rgb_to_rgb_matrix(ARRI_ALEXA_WG_PR
                                                                 AP0,
                                                                 CONE_RESP_MAT_CAT02);
 
-const float nominalEI = 400.0;
-const float blackSignal = 16.0 / 4095.0;
-const float midGraySignal = 0.01;
-const float encodingGain = 500.0 / 1023.0 * 0.525;
-const float encodingOffset = 400.0 / 1023.0;
-const float cut = 1.0 / 9.0;
-const float slope = 1.0 / (cut * log(10.0));
-const float offset = log10(cut) - slope * cut;
-
-float[4] hermiteWeights(float x, float x1, float x2)
-{
-    const float d = x2 - x1;
-    const float s = (x - x1) / d;
-    const float s2 = 1.0 - s;
-    float out[4];
-    out[0] = (1.0 + 2.0 * s) * s2 * s2;
-    out[1] = (3.0 - 2.0 * s) * s * s;
-    out[2] = d * s * s2 * s2;
-    out[3] = -d * s * s * s2;
-    return out;
-}
-
-float normalizedSensorToRelativeExposure(float ns, float EI)
-{
-    return (ns - blackSignal) * (0.18 / (midGraySignal * nominalEI / EI));
-}
-
-float normalizedLogC3ToRelativeExposure(float t, float EI)
-{
-    float nz;
-    float out;
-    float ns;
-    const float gain = EI / nominalEI;
-    const float gray = midGraySignal / gain;
-    const float encGain = (log2(gain) * (0.89 - 1.0) / 3.0 + 1.0) * encodingGain;
-    float encOffset = encodingOffset;
-    for (int i = 0; i < 3; i = i + 1)
-    {
-        nz = ((95.0 / 1023.0 - encOffset) / encGain - offset) / slope;
-        encOffset = encodingOffset - log10(1.0 + nz) * encGain;
-    }
-    float xm = log10((1.0 - blackSignal) / gray + nz) * encGain + encOffset;
-    if (xm > 1)
-    {
-        float hw[4] = hermiteWeights(t, 0.8, 1.0);
-        float d = 0.2 / (xm - 0.8);
-        float v[4];
-        v[0] = 0.8;
-        v[1] = xm;
-        v[2] = 1.0;
-        v[3] = 1.0 / (d * d);
-        if (t <= 0.8)
-        {
-            out = t;
-        }
-        else
-        {
-            out = hw[0] * v[0] + hw[1] * v[1] + hw[2] * v[2] + hw[3] * v[3];
-        }
-    }
-    else
-    {
-        out = t;
-    }
-    out = (out - encOffset) / encGain;
-    ns = (out - offset) / slope;
-    if (ns > cut)
-    {
-        ns = pow(10.0, out);
-    }
-    ns = (ns - nz) * gray + blackSignal;
-    return normalizedSensorToRelativeExposure(ns, EI);
-}
+const float EI = 500.0;
 
 void main(input varying float rIn,
           input varying float gIn,
@@ -113,8 +42,7 @@ void main(input varying float rIn,
           output varying float rOut,
           output varying float gOut,
           output varying float bOut,
-          output varying float aOut,
-          input uniform float EI = 500.0)
+          output varying float aOut)
 {
     float lin_AWG3[3];
     lin_AWG3[0] = normalizedLogC3ToRelativeExposure(rIn, EI);

--- a/arri/CSC.Arri.LogCv3-EI500_to_ACES.ctl
+++ b/arri/CSC.Arri.LogCv3-EI500_to_ACES.ctl
@@ -1,16 +1,14 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Contributors to the ACES Project.
 
-// <ACEStransformID>urn:ampas:aces:transformId:v2.0:CSC.Arri.LogC3_to_ACES.a2.v1</ACEStransformID>
-// <ACESuserName>ARRI LogC3 to ACES2065-1</ACESuserName>
+// <ACEStransformID>urn:ampas:aces:transformId:v2.0:CSC.Arri.LogC3-EI500_to_ACES.a2.v1</ACEStransformID>
+// <ACESuserName>ARRI LogC3 EI500 to ACES2065-1</ACESuserName>
 
 //
-// ACES Color Space Conversion - Arri LogC3 to ACES2065-1
+// ACES Color Space Conversion - Arri LogC3 EI500 to ACES2065-1
 //
-// converts Arri LogC3 to
+// converts Arri LogC3 EI500 to
 //          ACES2065-1 (AP0 w/ linear encoding)
-//
-// NOTE: In this transform EI is a parameter, defaulted to EI800.
 //
 
 import "Lib.Academy.Utilities";
@@ -116,7 +114,7 @@ void main(input varying float rIn,
           output varying float gOut,
           output varying float bOut,
           output varying float aOut,
-          input uniform float EI = 800.0)
+          input uniform float EI = 500.0)
 {
     float lin_AWG3[3];
     lin_AWG3[0] = normalizedLogC3ToRelativeExposure(rIn, EI);

--- a/arri/CSC.Arri.LogCv3-EI500_to_ACES.ctl
+++ b/arri/CSC.Arri.LogCv3-EI500_to_ACES.ctl
@@ -12,26 +12,7 @@
 //
 
 import "Lib.Academy.Utilities";
-import "Lib.Academy.ColorSpaces";
 import "Lib.Arri.LogC3";
-
-const Chromaticities AP0 = // ACES Primaries from SMPTE ST2065-1
-    {
-        {0.73470, 0.26530},
-        {0.00000, 1.00000},
-        {0.00010, -0.07700},
-        {0.32168, 0.33767}};
-
-const Chromaticities ARRI_ALEXA_WG_PRI =
-    {
-        {0.68400, 0.31300},
-        {0.22100, 0.84800},
-        {0.08610, -0.10200},
-        {0.31270, 0.32900}};
-
-const float AWG3_to_AP0_MAT[3][3] = calculate_rgb_to_rgb_matrix(ARRI_ALEXA_WG_PRI,
-                                                                AP0,
-                                                                CONE_RESP_MAT_CAT02);
 
 const float EI = 500.0;
 

--- a/arri/CSC.Arri.LogCv3-EI640_to_ACES.ctl
+++ b/arri/CSC.Arri.LogCv3-EI640_to_ACES.ctl
@@ -13,6 +13,7 @@
 
 import "Lib.Academy.Utilities";
 import "Lib.Academy.ColorSpaces";
+import "Lib.Arri.LogC3";
 
 const Chromaticities AP0 = // ACES Primaries from SMPTE ST2065-1
     {
@@ -32,79 +33,7 @@ const float AWG3_to_AP0_MAT[3][3] = calculate_rgb_to_rgb_matrix(ARRI_ALEXA_WG_PR
                                                                 AP0,
                                                                 CONE_RESP_MAT_CAT02);
 
-const float nominalEI = 400.0;
-const float blackSignal = 16.0 / 4095.0;
-const float midGraySignal = 0.01;
-const float encodingGain = 500.0 / 1023.0 * 0.525;
-const float encodingOffset = 400.0 / 1023.0;
-const float cut = 1.0 / 9.0;
-const float slope = 1.0 / (cut * log(10.0));
-const float offset = log10(cut) - slope * cut;
-
-float[4] hermiteWeights(float x, float x1, float x2)
-{
-    const float d = x2 - x1;
-    const float s = (x - x1) / d;
-    const float s2 = 1.0 - s;
-    float out[4];
-    out[0] = (1.0 + 2.0 * s) * s2 * s2;
-    out[1] = (3.0 - 2.0 * s) * s * s;
-    out[2] = d * s * s2 * s2;
-    out[3] = -d * s * s * s2;
-    return out;
-}
-
-float normalizedSensorToRelativeExposure(float ns, float EI)
-{
-    return (ns - blackSignal) * (0.18 / (midGraySignal * nominalEI / EI));
-}
-
-float normalizedLogC3ToRelativeExposure(float t, float EI)
-{
-    float nz;
-    float out;
-    float ns;
-    const float gain = EI / nominalEI;
-    const float gray = midGraySignal / gain;
-    const float encGain = (log2(gain) * (0.89 - 1.0) / 3.0 + 1.0) * encodingGain;
-    float encOffset = encodingOffset;
-    for (int i = 0; i < 3; i = i + 1)
-    {
-        nz = ((95.0 / 1023.0 - encOffset) / encGain - offset) / slope;
-        encOffset = encodingOffset - log10(1.0 + nz) * encGain;
-    }
-    float xm = log10((1.0 - blackSignal) / gray + nz) * encGain + encOffset;
-    if (xm > 1)
-    {
-        float hw[4] = hermiteWeights(t, 0.8, 1.0);
-        float d = 0.2 / (xm - 0.8);
-        float v[4];
-        v[0] = 0.8;
-        v[1] = xm;
-        v[2] = 1.0;
-        v[3] = 1.0 / (d * d);
-        if (t <= 0.8)
-        {
-            out = t;
-        }
-        else
-        {
-            out = hw[0] * v[0] + hw[1] * v[1] + hw[2] * v[2] + hw[3] * v[3];
-        }
-    }
-    else
-    {
-        out = t;
-    }
-    out = (out - encOffset) / encGain;
-    ns = (out - offset) / slope;
-    if (ns > cut)
-    {
-        ns = pow(10.0, out);
-    }
-    ns = (ns - nz) * gray + blackSignal;
-    return normalizedSensorToRelativeExposure(ns, EI);
-}
+const float EI = 640.0;
 
 void main(input varying float rIn,
           input varying float gIn,
@@ -113,8 +42,7 @@ void main(input varying float rIn,
           output varying float rOut,
           output varying float gOut,
           output varying float bOut,
-          output varying float aOut,
-          input uniform float EI = 640.0)
+          output varying float aOut)
 {
     float lin_AWG3[3];
     lin_AWG3[0] = normalizedLogC3ToRelativeExposure(rIn, EI);

--- a/arri/CSC.Arri.LogCv3-EI640_to_ACES.ctl
+++ b/arri/CSC.Arri.LogCv3-EI640_to_ACES.ctl
@@ -1,16 +1,14 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Contributors to the ACES Project.
 
-// <ACEStransformID>urn:ampas:aces:transformId:v2.0:CSC.Arri.LogC3_to_ACES.a2.v1</ACEStransformID>
-// <ACESuserName>ARRI LogC3 to ACES2065-1</ACESuserName>
+// <ACEStransformID>urn:ampas:aces:transformId:v2.0:CSC.Arri.LogC3-EI640_to_ACES.a2.v1</ACEStransformID>
+// <ACESuserName>ARRI LogC3 EI640 to ACES2065-1</ACESuserName>
 
 //
-// ACES Color Space Conversion - Arri LogC3 to ACES2065-1
+// ACES Color Space Conversion - Arri LogC3 EI640 to ACES2065-1
 //
-// converts Arri LogC3 to
+// converts Arri LogC3 EI640 to
 //          ACES2065-1 (AP0 w/ linear encoding)
-//
-// NOTE: In this transform EI is a parameter, defaulted to EI800.
 //
 
 import "Lib.Academy.Utilities";
@@ -116,7 +114,7 @@ void main(input varying float rIn,
           output varying float gOut,
           output varying float bOut,
           output varying float aOut,
-          input uniform float EI = 800.0)
+          input uniform float EI = 640.0)
 {
     float lin_AWG3[3];
     lin_AWG3[0] = normalizedLogC3ToRelativeExposure(rIn, EI);

--- a/arri/CSC.Arri.LogCv3-EI640_to_ACES.ctl
+++ b/arri/CSC.Arri.LogCv3-EI640_to_ACES.ctl
@@ -12,26 +12,7 @@
 //
 
 import "Lib.Academy.Utilities";
-import "Lib.Academy.ColorSpaces";
 import "Lib.Arri.LogC3";
-
-const Chromaticities AP0 = // ACES Primaries from SMPTE ST2065-1
-    {
-        {0.73470, 0.26530},
-        {0.00000, 1.00000},
-        {0.00010, -0.07700},
-        {0.32168, 0.33767}};
-
-const Chromaticities ARRI_ALEXA_WG_PRI =
-    {
-        {0.68400, 0.31300},
-        {0.22100, 0.84800},
-        {0.08610, -0.10200},
-        {0.31270, 0.32900}};
-
-const float AWG3_to_AP0_MAT[3][3] = calculate_rgb_to_rgb_matrix(ARRI_ALEXA_WG_PRI,
-                                                                AP0,
-                                                                CONE_RESP_MAT_CAT02);
 
 const float EI = 640.0;
 

--- a/arri/CSC.Arri.LogCv3-EI800_to_ACES.ctl
+++ b/arri/CSC.Arri.LogCv3-EI800_to_ACES.ctl
@@ -1,16 +1,14 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Contributors to the ACES Project.
 
-// <ACEStransformID>urn:ampas:aces:transformId:v2.0:CSC.Arri.LogC3_to_ACES.a2.v1</ACEStransformID>
-// <ACESuserName>ARRI LogC3 to ACES2065-1</ACESuserName>
+// <ACEStransformID>urn:ampas:aces:transformId:v2.0:CSC.Arri.LogC3-EI800_to_ACES.a2.v1</ACEStransformID>
+// <ACESuserName>ARRI LogC3 EI800 to ACES2065-1</ACESuserName>
 
 //
-// ACES Color Space Conversion - Arri LogC3 to ACES2065-1
+// ACES Color Space Conversion - Arri LogC3 EI800 to ACES2065-1
 //
-// converts Arri LogC3 to
+// converts Arri LogC3 EI800 to
 //          ACES2065-1 (AP0 w/ linear encoding)
-//
-// NOTE: In this transform EI is a parameter, defaulted to EI800.
 //
 
 import "Lib.Academy.Utilities";

--- a/arri/CSC.Arri.LogCv3-EI800_to_ACES.ctl
+++ b/arri/CSC.Arri.LogCv3-EI800_to_ACES.ctl
@@ -13,6 +13,7 @@
 
 import "Lib.Academy.Utilities";
 import "Lib.Academy.ColorSpaces";
+import "Lib.Arri.LogC3";
 
 const Chromaticities AP0 = // ACES Primaries from SMPTE ST2065-1
     {
@@ -32,79 +33,7 @@ const float AWG3_to_AP0_MAT[3][3] = calculate_rgb_to_rgb_matrix(ARRI_ALEXA_WG_PR
                                                                 AP0,
                                                                 CONE_RESP_MAT_CAT02);
 
-const float nominalEI = 400.0;
-const float blackSignal = 16.0 / 4095.0;
-const float midGraySignal = 0.01;
-const float encodingGain = 500.0 / 1023.0 * 0.525;
-const float encodingOffset = 400.0 / 1023.0;
-const float cut = 1.0 / 9.0;
-const float slope = 1.0 / (cut * log(10.0));
-const float offset = log10(cut) - slope * cut;
-
-float[4] hermiteWeights(float x, float x1, float x2)
-{
-    const float d = x2 - x1;
-    const float s = (x - x1) / d;
-    const float s2 = 1.0 - s;
-    float out[4];
-    out[0] = (1.0 + 2.0 * s) * s2 * s2;
-    out[1] = (3.0 - 2.0 * s) * s * s;
-    out[2] = d * s * s2 * s2;
-    out[3] = -d * s * s * s2;
-    return out;
-}
-
-float normalizedSensorToRelativeExposure(float ns, float EI)
-{
-    return (ns - blackSignal) * (0.18 / (midGraySignal * nominalEI / EI));
-}
-
-float normalizedLogC3ToRelativeExposure(float t, float EI)
-{
-    float nz;
-    float out;
-    float ns;
-    const float gain = EI / nominalEI;
-    const float gray = midGraySignal / gain;
-    const float encGain = (log2(gain) * (0.89 - 1.0) / 3.0 + 1.0) * encodingGain;
-    float encOffset = encodingOffset;
-    for (int i = 0; i < 3; i = i + 1)
-    {
-        nz = ((95.0 / 1023.0 - encOffset) / encGain - offset) / slope;
-        encOffset = encodingOffset - log10(1.0 + nz) * encGain;
-    }
-    float xm = log10((1.0 - blackSignal) / gray + nz) * encGain + encOffset;
-    if (xm > 1)
-    {
-        float hw[4] = hermiteWeights(t, 0.8, 1.0);
-        float d = 0.2 / (xm - 0.8);
-        float v[4];
-        v[0] = 0.8;
-        v[1] = xm;
-        v[2] = 1.0;
-        v[3] = 1.0 / (d * d);
-        if (t <= 0.8)
-        {
-            out = t;
-        }
-        else
-        {
-            out = hw[0] * v[0] + hw[1] * v[1] + hw[2] * v[2] + hw[3] * v[3];
-        }
-    }
-    else
-    {
-        out = t;
-    }
-    out = (out - encOffset) / encGain;
-    ns = (out - offset) / slope;
-    if (ns > cut)
-    {
-        ns = pow(10.0, out);
-    }
-    ns = (ns - nz) * gray + blackSignal;
-    return normalizedSensorToRelativeExposure(ns, EI);
-}
+const float EI = 800.0;
 
 void main(input varying float rIn,
           input varying float gIn,
@@ -113,8 +42,7 @@ void main(input varying float rIn,
           output varying float rOut,
           output varying float gOut,
           output varying float bOut,
-          output varying float aOut,
-          input uniform float EI = 800.0)
+          output varying float aOut)
 {
     float lin_AWG3[3];
     lin_AWG3[0] = normalizedLogC3ToRelativeExposure(rIn, EI);

--- a/arri/CSC.Arri.LogCv3-EI800_to_ACES.ctl
+++ b/arri/CSC.Arri.LogCv3-EI800_to_ACES.ctl
@@ -12,26 +12,7 @@
 //
 
 import "Lib.Academy.Utilities";
-import "Lib.Academy.ColorSpaces";
 import "Lib.Arri.LogC3";
-
-const Chromaticities AP0 = // ACES Primaries from SMPTE ST2065-1
-    {
-        {0.73470, 0.26530},
-        {0.00000, 1.00000},
-        {0.00010, -0.07700},
-        {0.32168, 0.33767}};
-
-const Chromaticities ARRI_ALEXA_WG_PRI =
-    {
-        {0.68400, 0.31300},
-        {0.22100, 0.84800},
-        {0.08610, -0.10200},
-        {0.31270, 0.32900}};
-
-const float AWG3_to_AP0_MAT[3][3] = calculate_rgb_to_rgb_matrix(ARRI_ALEXA_WG_PRI,
-                                                                AP0,
-                                                                CONE_RESP_MAT_CAT02);
 
 const float EI = 800.0;
 

--- a/arri/CSC.Arri.LogCv3_to_ACES.ctl
+++ b/arri/CSC.Arri.LogCv3_to_ACES.ctl
@@ -15,6 +15,7 @@
 
 import "Lib.Academy.Utilities";
 import "Lib.Academy.ColorSpaces";
+import "Lib.Arri.LogC3";
 
 const Chromaticities AP0 = // ACES Primaries from SMPTE ST2065-1
     {
@@ -33,80 +34,6 @@ const Chromaticities ARRI_ALEXA_WG_PRI =
 const float AWG3_to_AP0_MAT[3][3] = calculate_rgb_to_rgb_matrix(ARRI_ALEXA_WG_PRI,
                                                                 AP0,
                                                                 CONE_RESP_MAT_CAT02);
-
-const float nominalEI = 400.0;
-const float blackSignal = 16.0 / 4095.0;
-const float midGraySignal = 0.01;
-const float encodingGain = 500.0 / 1023.0 * 0.525;
-const float encodingOffset = 400.0 / 1023.0;
-const float cut = 1.0 / 9.0;
-const float slope = 1.0 / (cut * log(10.0));
-const float offset = log10(cut) - slope * cut;
-
-float[4] hermiteWeights(float x, float x1, float x2)
-{
-    const float d = x2 - x1;
-    const float s = (x - x1) / d;
-    const float s2 = 1.0 - s;
-    float out[4];
-    out[0] = (1.0 + 2.0 * s) * s2 * s2;
-    out[1] = (3.0 - 2.0 * s) * s * s;
-    out[2] = d * s * s2 * s2;
-    out[3] = -d * s * s * s2;
-    return out;
-}
-
-float normalizedSensorToRelativeExposure(float ns, float EI)
-{
-    return (ns - blackSignal) * (0.18 / (midGraySignal * nominalEI / EI));
-}
-
-float normalizedLogC3ToRelativeExposure(float t, float EI)
-{
-    float nz;
-    float out;
-    float ns;
-    const float gain = EI / nominalEI;
-    const float gray = midGraySignal / gain;
-    const float encGain = (log2(gain) * (0.89 - 1.0) / 3.0 + 1.0) * encodingGain;
-    float encOffset = encodingOffset;
-    for (int i = 0; i < 3; i = i + 1)
-    {
-        nz = ((95.0 / 1023.0 - encOffset) / encGain - offset) / slope;
-        encOffset = encodingOffset - log10(1.0 + nz) * encGain;
-    }
-    float xm = log10((1.0 - blackSignal) / gray + nz) * encGain + encOffset;
-    if (xm > 1)
-    {
-        float hw[4] = hermiteWeights(t, 0.8, 1.0);
-        float d = 0.2 / (xm - 0.8);
-        float v[4];
-        v[0] = 0.8;
-        v[1] = xm;
-        v[2] = 1.0;
-        v[3] = 1.0 / (d * d);
-        if (t <= 0.8)
-        {
-            out = t;
-        }
-        else
-        {
-            out = hw[0] * v[0] + hw[1] * v[1] + hw[2] * v[2] + hw[3] * v[3];
-        }
-    }
-    else
-    {
-        out = t;
-    }
-    out = (out - encOffset) / encGain;
-    ns = (out - offset) / slope;
-    if (ns > cut)
-    {
-        ns = pow(10.0, out);
-    }
-    ns = (ns - nz) * gray + blackSignal;
-    return normalizedSensorToRelativeExposure(ns, EI);
-}
 
 void main(input varying float rIn,
           input varying float gIn,

--- a/arri/CSC.Arri.LogCv3_to_ACES.ctl
+++ b/arri/CSC.Arri.LogCv3_to_ACES.ctl
@@ -14,26 +14,7 @@
 //
 
 import "Lib.Academy.Utilities";
-import "Lib.Academy.ColorSpaces";
 import "Lib.Arri.LogC3";
-
-const Chromaticities AP0 = // ACES Primaries from SMPTE ST2065-1
-    {
-        {0.73470, 0.26530},
-        {0.00000, 1.00000},
-        {0.00010, -0.07700},
-        {0.32168, 0.33767}};
-
-const Chromaticities ARRI_ALEXA_WG_PRI =
-    {
-        {0.68400, 0.31300},
-        {0.22100, 0.84800},
-        {0.08610, -0.10200},
-        {0.31270, 0.32900}};
-
-const float AWG3_to_AP0_MAT[3][3] = calculate_rgb_to_rgb_matrix(ARRI_ALEXA_WG_PRI,
-                                                                AP0,
-                                                                CONE_RESP_MAT_CAT02);
 
 void main(input varying float rIn,
           input varying float gIn,

--- a/arri/Lib.Arri.LogC3.ctl
+++ b/arri/Lib.Arri.LogC3.ctl
@@ -1,0 +1,129 @@
+// <ACEStransformID>urn:ampas:aces:transformId:v2.0:Lib.Arri.LogC3.a2.v1</ACEStransformID>
+// <ACESuserName>LogC3 Constants and Functions</ACESuserName>
+
+//
+// LogC3 Constants and Functions
+//
+// NOTE: Due to the Hermite spline blending region between 0.8 and 1.0, the
+// relativeExposureToNormalizedLogC3() function is only defined for EI values
+// below 1600.
+//
+
+const float nominalEI = 400.0;
+const float blackSignal = 16.0 / 4095.0;
+const float midGraySignal = 0.01;
+const float encodingGain = 500.0 / 1023.0 * 0.525;
+const float encodingOffset = 400.0 / 1023.0;
+const float cut = 1.0 / 9.0;
+const float slope = 1.0 / (cut * log(10.0));
+const float offset = log10(cut) - slope * cut;
+
+float[4] hermiteWeights(float x, float x1, float x2)
+{
+    const float d = x2 - x1;
+    const float s = (x - x1) / d;
+    const float s2 = 1.0 - s;
+    float out[4];
+    out[0] = (1.0 + 2.0 * s) * s2 * s2;
+    out[1] = (3.0 - 2.0 * s) * s * s;
+    out[2] = d * s * s2 * s2;
+    out[3] = -d * s * s * s2;
+    return out;
+}
+
+float normalizedSensorToRelativeExposure(float ns, float EI)
+{
+    return (ns - blackSignal) * (0.18 / (midGraySignal * nominalEI / EI));
+}
+
+float normalizedLogC3ToRelativeExposure(float t, float EI)
+{
+    float nz;
+    float out;
+    float ns;
+    const float gain = EI / nominalEI;
+    const float gray = midGraySignal / gain;
+    const float encGain = (log2(gain) * (0.89 - 1.0) / 3.0 + 1.0) * encodingGain;
+    float encOffset = encodingOffset;
+    for (int i = 0; i < 3; i = i + 1)
+    {
+        nz = ((95.0 / 1023.0 - encOffset) / encGain - offset) / slope;
+        encOffset = encodingOffset - log10(1.0 + nz) * encGain;
+    }
+    float xm = log10((1.0 - blackSignal) / gray + nz) * encGain + encOffset;
+    if (xm > 1)
+    {
+        float hw[4] = hermiteWeights(t, 0.8, 1.0);
+        float d = 0.2 / (xm - 0.8);
+        float v[4];
+        v[0] = 0.8;
+        v[1] = xm;
+        v[2] = 1.0;
+        v[3] = 1.0 / (d * d);
+        if (t <= 0.8)
+        {
+            out = t;
+        }
+        else
+        {
+            out = hw[0] * v[0] + hw[1] * v[1] + hw[2] * v[2] + hw[3] * v[3];
+        }
+    }
+    else
+    {
+        out = t;
+    }
+    out = (out - encOffset) / encGain;
+    ns = (out - offset) / slope;
+    if (ns > cut)
+    {
+        ns = pow(10.0, out);
+    }
+    ns = (ns - nz) * gray + blackSignal;
+    return normalizedSensorToRelativeExposure(ns, EI);
+}
+
+float relativeExposureToNormalizedSensor(float re, float EI)
+{
+    return re * (midGraySignal * nominalEI / EI) / 0.18 + blackSignal;
+}
+
+float relativeExposureToNormalizedLogC3(float re, float EI)
+{
+    float nz;
+    float out;
+    float ns;
+    const float gain = EI / nominalEI;
+    const float gray = midGraySignal / gain;
+    const float encGain = (log2(gain) * (0.89 - 1.0) / 3.0 + 1.0) * encodingGain;
+    float encOffset = encodingOffset;
+    for (int i = 0; i < 3; i = i + 1)
+    {
+        nz = ((95.0 / 1023.0 - encOffset) / encGain - offset) / slope;
+        encOffset = encodingOffset - log10(1.0 + nz) * encGain;
+    }
+    float xm = log10((1.0 - blackSignal) / gray + nz) * encGain + encOffset;
+
+    ns = relativeExposureToNormalizedSensor(re, EI);
+
+    ns = (ns - blackSignal) / gray + nz;
+
+    if (xm > 1) {
+        // Hermite blending region
+        // Tricky to implement an inverse unless needed. It might be possible to
+        // iteratively solve for a numerical inversion, but is currently not
+        // supported.
+        return 0;
+    } else { // Valid for EI values below 1600
+        if (ns > cut)
+        {
+            out = log10(ns);
+        } 
+        else
+        {
+            out = slope * ns + offset;
+        }
+    }
+
+    return out * encGain + encOffset;
+}

--- a/arri/Lib.Arri.LogC3.ctl
+++ b/arri/Lib.Arri.LogC3.ctl
@@ -4,6 +4,34 @@
 //
 // LogC3 Constants and Functions
 //
+
+import "Lib.Academy.ColorSpaces";
+
+const Chromaticities AP0 = // ACES Primaries from SMPTE ST2065-1
+    {
+        {0.73470, 0.26530},
+        {0.00000, 1.00000},
+        {0.00010, -0.07700},
+        {0.32168, 0.33767}};
+
+const Chromaticities ARRI_ALEXA_WG_PRI =
+    {
+        {0.68400, 0.31300},
+        {0.22100, 0.84800},
+        {0.08610, -0.10200},
+        {0.31270, 0.32900}};
+
+const float AP0_to_AWG3_MAT[3][3] = calculate_rgb_to_rgb_matrix(AP0,
+                                                                ARRI_ALEXA_WG_PRI,
+                                                                CONE_RESP_MAT_CAT02);
+
+const float AWG3_to_AP0_MAT[3][3] = calculate_rgb_to_rgb_matrix(ARRI_ALEXA_WG_PRI,
+                                                                AP0,
+                                                                CONE_RESP_MAT_CAT02);
+
+//
+// LogC3 Constants and Functions
+//
 // NOTE: Due to the Hermite spline blending region between 0.8 and 1.0, the
 // relativeExposureToNormalizedLogC3() function is only defined for EI values
 // below 1600.


### PR DESCRIPTION
This branch begins to address Issue #18.

There are a few points that need discussion, highlighted below:

1. These transforms copy the parameterized base transform and set a Transform ID and User Name for each EI value, rather than using the `v3_IDT_maker.py`.
    - This duplicates a lot of code, but lets the transforms run independently without adding another import to utilize the parameterized transform. However, there are imports of Utilities and Colorspaces, so maybe another import isn't so bad?
    - Any preferences one way or the other on how to construct these - copy/paste explicit code or import to keep more compact? 
2. I opted to use a hyphen (`LogCv3-EI###`) vs an underscore (`LogCv3_EI###) in the filename
    - Any preference here?
3. I kept the filename as `LogCv3` to match the other files in the directory, but inside the functions we call it LogC3 (no 'v').
    - Is there a preferred syntax? 
      - (need to consider compatibility implications of changing filenames - maybe plan for a future release?)
4. I left the parameterized form alongside the specific EI transforms. This is because some implementations of ACES v2 have already built off the generalized transform.
    - Anybody see any harm in leaving both?
5. Transforms for the ACES to LogC direction for EIs 1600, 2000, 2560, 3200 are not provided because they're not defined with the formulaic implementation. 
    - Ok to omit? Or do we alter the structure for these and try to provide LUT based inverses?